### PR TITLE
Add Theme Colors Storybook

### DIFF
--- a/stories/Theme.stories.tsx
+++ b/stories/Theme.stories.tsx
@@ -14,6 +14,7 @@ export default meta;
 const ColorCard = ({ color }: { color: SingleColor }) => {
   return (
     <VStack
+      spacing={0}
       w="100px"
       h="100px"
       flex="0 0 100px"
@@ -23,7 +24,7 @@ const ColorCard = ({ color }: { color: SingleColor }) => {
       borderRadius="sm"
     >
       <Box flex="1 0 auto" w="100%" bg={color.value} />
-      <Text fontSize="xs" px={1}>
+      <Text fontSize="xs" p={1} mt={0}>
         {color.title}
       </Text>
     </VStack>

--- a/stories/Theme.stories.tsx
+++ b/stories/Theme.stories.tsx
@@ -4,8 +4,9 @@ import { Box, Text, HStack, useTheme, VStack, Heading } from '@chakra-ui/react';
 
 const meta: Meta = {
   title: 'Theme',
+  // showPanel: false,
   parameters: {
-    controls: { expanded: false },
+    options: { showPanel: false },
   },
 };
 

--- a/stories/Theme.stories.tsx
+++ b/stories/Theme.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { Box, Text, HStack, useTheme, VStack } from '@chakra-ui/react';
+import { Box, Text, HStack, useTheme, VStack, Heading } from '@chakra-ui/react';
 
 const meta: Meta = {
   title: 'Theme',
@@ -15,9 +15,9 @@ const ColorCard = ({ color }: { color: SingleColor }) => {
   return (
     <VStack
       spacing={0}
-      w="100px"
+      w="160px"
       h="100px"
-      flex="0 0 100px"
+      flex="0 0 160px"
       display="flex"
       my={2}
       border="1px solid black"
@@ -66,26 +66,39 @@ export const Colors = () => {
     'black',
     'white',
     'whiteAlpha',
+    'ui',
+    'brand',
   ];
 
-  const keys = Object.keys(themeColors).filter((key) => !ignored.includes(key));
+  const colorScalesKeys = Object.keys(themeColors).filter(
+    (key) => !ignored.includes(key)
+  );
+  const uiColorsKeys = Object.keys(themeColors.ui);
 
-  const colors = keys.map((key) => {
-    const value = themeColors[key];
+  const flattenObject = (obj: any, prefix: string) => (key: string) => {
+    const value = obj[key];
     if (typeof value === 'string') {
-      return { title: key, value };
+      return { title: `${prefix}${key}`, value };
     }
     return {
       title: key,
       children: Object.keys(value).map((subkey: string) => {
-        return { title: `${key}.${subkey}`, value: value[subkey] };
+        return { title: `${prefix}${key}.${subkey}`, value: value[subkey] };
       }),
     };
-  });
+  };
+
+  const colorScales = colorScalesKeys.map(flattenObject(themeColors, ''));
+  const uiColors = uiColorsKeys.map(flattenObject(themeColors.ui, 'ui.'));
 
   return (
     <>
-      {colors.map((color) => (
+      <Heading>UI Colors</Heading>
+      {uiColors.map((color) => (
+        <ColorRow color={color} key={color.title} />
+      ))}
+      <Heading>Color Scales</Heading>
+      {colorScales.map((color) => (
         <ColorRow color={color} key={color.title} />
       ))}
     </>

--- a/stories/Theme.stories.tsx
+++ b/stories/Theme.stories.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { Box, Text, HStack, useTheme, VStack } from '@chakra-ui/react';
+
+const meta: Meta = {
+  title: 'Theme',
+  parameters: {
+    controls: { expanded: false },
+  },
+};
+
+export default meta;
+
+const ColorCard = ({ color }: { color: SingleColor }) => {
+  return (
+    <VStack
+      w="100px"
+      h="100px"
+      flex="0 0 100px"
+      display="flex"
+      my={2}
+      border="1px solid black"
+      borderRadius="sm"
+    >
+      <Box flex="1 0 auto" w="100%" bg={color.value} />
+      <Text fontSize="xs" px={1}>
+        {color.title}
+      </Text>
+    </VStack>
+  );
+};
+
+type SingleColor = { title: string; value: string };
+type MultiColor = { title: string; children: SingleColor[] };
+
+const ColorRow = ({ color }: { color: SingleColor | MultiColor }) => {
+  if ('value' in color) {
+    return <ColorCard color={color} />;
+  }
+  return (
+    <HStack direction="column">
+      {color.children.map((color) => (
+        <ColorCard color={color} key={color.title} />
+      ))}
+    </HStack>
+  );
+};
+
+export const Colors = () => {
+  const theme = useTheme();
+
+  const themeColors: Record<string, string | Record<string, string>> =
+    theme.colors;
+
+  // colors provided by chakra we just want to ignore
+  const ignored = [
+    'facebook',
+    'twitter',
+    'telegram',
+    'whatsapp',
+    'linkedin',
+    'messenger',
+    'transparent',
+    'current',
+    'black',
+    'white',
+    'whiteAlpha',
+  ];
+
+  const keys = Object.keys(themeColors).filter((key) => !ignored.includes(key));
+
+  const colors = keys.map((key) => {
+    const value = themeColors[key];
+    if (typeof value === 'string') {
+      return { title: key, value };
+    }
+    return {
+      title: key,
+      children: Object.keys(value).map((subkey: string) => {
+        return { title: `${key}.${subkey}`, value: value[subkey] };
+      }),
+    };
+  });
+
+  return (
+    <>
+      {colors.map((color) => (
+        <ColorRow color={color} key={color.title} />
+      ))}
+    </>
+  );
+};


### PR DESCRIPTION
This PR adds a story to the storybook to render all the colors currently in the theme. We should be using these colors instead of hardcoding new values almost always. In cases where there is not an applicable color, we should make a new value in the theme. 