### PR TITLE
add aria-lable to radio group

### DIFF
--- a/src/ui/SettingsButton.tsx
+++ b/src/ui/SettingsButton.tsx
@@ -48,7 +48,7 @@ export default function SettingsCard({ navigator }: { navigator: Navigator }) {
           _active={{ boxShadow: 'none' }}
         >
           <PopoverBody p={0}>
-            <ToggleGroup defaultValue="publisher">
+            <ToggleGroup value="publisher" label="text font options">
               <ToggleButton value="publisher">Publisher</ToggleButton>
               <ToggleButton value="serif">Serif</ToggleButton>
               <ToggleButton value="sans-serif">Sans-Serif</ToggleButton>
@@ -56,7 +56,7 @@ export default function SettingsCard({ navigator }: { navigator: Navigator }) {
                 Dyslexia-Friendly
               </ToggleButton>
             </ToggleGroup>
-            <ToggleGroup defaultValue="day">
+            <ToggleGroup value="day" label="reading theme options">
               <ToggleButton colorScheme="light" value="day" variant="solid">
                 Day
               </ToggleButton>
@@ -70,7 +70,7 @@ export default function SettingsCard({ navigator }: { navigator: Navigator }) {
             <ToggleGroup
               onChange={setScroll}
               value={paginationValue}
-              defaultValue="paginated"
+              label="pagination options"
             >
               <ToggleButton value="paginated">Paginated</ToggleButton>
               <ToggleButton value="scrolling">Scrolling</ToggleButton>

--- a/src/ui/ToggleGroup.tsx
+++ b/src/ui/ToggleGroup.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { useRadioGroup, UseRadioGroupProps } from '@chakra-ui/react';
 
-type ToggleGroupProps = UseRadioGroupProps;
+type ToggleGroupProps = Omit<UseRadioGroupProps, 'value' | 'defaultValue'> & {
+  value: string;
+  label: string;
+};
 
 const ToggleGroup: React.FC<ToggleGroupProps> = ({
-  defaultValue,
   value,
+  label,
   name,
   children,
   onChange,
 }) => {
   const { getRootProps, getRadioProps } = useRadioGroup({
     name,
-    defaultValue,
     onChange,
     value,
   });
@@ -20,7 +22,7 @@ const ToggleGroup: React.FC<ToggleGroupProps> = ({
   const group = getRootProps();
 
   return (
-    <div {...group}>
+    <div {...group} aria-label={label}>
       {React.Children.map(children, (element) => {
         try {
           const value = (element as any).props.value;

--- a/stories/SettingsCard.stories.tsx
+++ b/stories/SettingsCard.stories.tsx
@@ -15,13 +15,13 @@ export default meta;
 export const SettingsCard = () => {
   return (
     <div>
-      <ToggleGroup defaultValue="publisher">
+      <ToggleGroup value="publisher" label="text font options">
         <ToggleButton value="publisher">Publisher</ToggleButton>
         <ToggleButton value="serif">Serif</ToggleButton>
         <ToggleButton value="sans-serif">Sans-Serif</ToggleButton>
         <ToggleButton value="dyslexia-friendly">Dyslexia-Friendly</ToggleButton>
       </ToggleGroup>
-      <ToggleGroup defaultValue="day">
+      <ToggleGroup value="day" label="reading theme options">
         <ToggleButton colorScheme="light" value="day" variant="solid">
           Day
         </ToggleButton>
@@ -32,7 +32,7 @@ export const SettingsCard = () => {
           Night
         </ToggleButton>
       </ToggleGroup>
-      <ToggleGroup defaultValue="paginated">
+      <ToggleGroup value="paginated" label="pagination options">
         <ToggleButton value="paginated">Paginated</ToggleButton>
         <ToggleButton value="scrolling">Scrolling</ToggleButton>
       </ToggleGroup>

--- a/tests/ToggleGroup.test.tsx
+++ b/tests/ToggleGroup.test.tsx
@@ -5,7 +5,7 @@ import ToggleGroup from '../src/ui/ToggleGroup';
 
 const renderComponent = () => {
   return render(
-    <ToggleGroup value="sedona">
+    <ToggleGroup value="sedona" label="test">
       <ToggleButton value="sedona">Sedona</ToggleButton>
       <ToggleButton value="santa_fe">Santa Fe</ToggleButton>
       <ToggleButton value="las_cruces">Las Cruces</ToggleButton>
@@ -15,7 +15,7 @@ const renderComponent = () => {
 
 test('radiogroup should be in the document', () => {
   const { getByRole } = renderComponent();
-  expect(getByRole('radiogroup')).toBeInTheDocument();
+  expect(getByRole('radiogroup', { name: 'test' })).toBeInTheDocument();
 });
 
 test('toggle group should contain all radio buttons', () => {
@@ -36,7 +36,7 @@ test('respect value props', () => {
 test('onChange callback function should be called', () => {
   const onChangeHandler = jest.fn();
   const { getByLabelText } = render(
-    <ToggleGroup value="sedona" onChange={onChangeHandler}>
+    <ToggleGroup value="sedona" onChange={onChangeHandler} label="test">
       <ToggleButton value="sedona">Sedona</ToggleButton>
       <ToggleButton value="santa_fe">Santa Fe</ToggleButton>
       <ToggleButton value="las_cruces">Las Cruces</ToggleButton>


### PR DESCRIPTION
This PR adds the `label` prop to the `radiogroup` component. `label` should be a required prop. 