### PR TITLE
NO-REF Added direct link to fix parcel build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web-reader",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "src"
   ],
   "scripts": {
-    "example:build": "parcel build",
-    "example:nocache": "parcel --no-cache",
-    "example": "parcel",
-    "example:https": "parcel --cert localhost.pem --key localhost-key.pem",
+    "example:build": "parcel build example/index.html",
+    "example:nocache": "parcel example/index.html --no-cache",
+    "example": "parcel example/index.html",
+    "example:https": "parcel  example/index.html --cert localhost.pem --key localhost-key.pem",
     "example:sw": "ENABLE_SW=true npm run example:https",
     "start": "tsdx watch --tsconfig tsconfig.build.json",
     "build": "tsdx build --tsconfig tsconfig.build.json",


### PR DESCRIPTION
running `parcel build` was throwing an error where it was looking inside the wrong root directory inside `parcel-reporter-static-files-copy`.  
This was stopping the build and making it so that the build was failing.  

My current theory is that it has something to do with this bug:  https://github.com/parcel-bundler/parcel/issues/6729 
However, making direct reference to the files seems to fix the problem.  

Would love insight into whether anyone else was having this error - it started appearing very recently for me, and this bug is about a month old. 