### PR TITLE
Add back-to-host option to the WebReader

### DIFF
--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -5,11 +5,11 @@ describe('navigating an EPUB page', () => {
     cy.loadPage('/streamed-alice-epub');
   });
 
-  it('should contain the NYPL homepage url', () => {
-    cy.findByRole('link', { name: 'Return to NYPL' }).should(
+  it('should contain a link to return to the homepage', () => {
+    cy.findByRole('link', { name: 'Return to Homepage' }).should(
       'have.prop',
       'href',
-      'https://www.nypl.org/'
+      '/'
     );
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { UseWebReaderArguments } from './types';
+import { ReaderManagerArguments, UseWebReaderArguments } from './types';
 import ManagerUI from './ui/manager';
 import useWebReader from './useWebReader';
 
@@ -7,10 +7,11 @@ import useWebReader from './useWebReader';
  * The main React component export.
  */
 
-const WebReader: FC<UseWebReaderArguments> = ({
+const WebReader: FC<UseWebReaderArguments & ReaderManagerArguments> = ({
   webpubManifestUrl,
   proxyUrl,
   getContent,
+  headerLeft,
 }) => {
   const webReader = useWebReader({
     webpubManifestUrl,
@@ -19,7 +20,11 @@ const WebReader: FC<UseWebReaderArguments> = ({
   });
   const { content } = webReader;
 
-  return <ManagerUI {...webReader}>{content}</ManagerUI>;
+  return (
+    <ManagerUI headerLeft={headerLeft} {...webReader}>
+      {content}
+    </ManagerUI>
+  );
 };
 
 export default WebReader;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,10 @@ export type ReaderReturn = InactiveReader | LoadingReader | ActiveReader;
 // should fetch and decrypt a resource
 export type GetContent = (href: string) => Promise<string>;
 
+export type ReaderManagerArguments = {
+  headerLeft?: JSX.Element; // Top-left header section
+};
+
 export type UseWebReaderArguments = {
   webpubManifestUrl: string;
   proxyUrl?: string;

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { Flex, Link, HStack, Text, chakra } from '@chakra-ui/react';
-import {
-  Icon,
-  IconNames,
-  LogoNames,
-} from '@nypl/design-system-react-components';
-import { ActiveReader } from '../types';
+import { Flex, Link, HStack, Text } from '@chakra-ui/react';
+import { Icon, IconNames } from '@nypl/design-system-react-components';
+import { ActiveReader, ReaderManagerArguments } from '../types';
 import useColorModeValue from '../ui/hooks/useColorModeValue';
 import { toggleFullScreen } from '../utils/toggleFullScreen';
 
@@ -14,21 +10,34 @@ import Button from './Button';
 import TableOfContent from './TableOfContent';
 import { HEADER_HEIGHT } from './constants';
 
-export type HeaderProps = ActiveReader & {
-  headerLeft?: React.ReactNode; // Top-left header section
+const DefaultHeaderLeft = (): React.ReactElement => {
+  const linkColor = useColorModeValue('gray.700', 'gray.100', 'gray.700');
+  return (
+    <Link
+      href="/"
+      aria-label="Return to Homepage"
+      tabIndex={0}
+      fontSize={0}
+      py={1}
+      textTransform="uppercase"
+      d="flex"
+      color={linkColor}
+      height="100%"
+      alignItems="center"
+      _hover={{
+        textDecoration: 'none',
+      }}
+    >
+      <Text variant="headerNav">Back to Homepage</Text>
+    </Link>
+  );
 };
 
-export default function Header(props: HeaderProps): React.ReactElement {
+export default function Header(
+  props: ActiveReader & ReaderManagerArguments
+): React.ReactElement {
   const { headerLeft, state, navigator, manifest } = props;
-  const linkColor = useColorModeValue('gray.700', 'gray.100', 'gray.700');
   const mainBgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
-
-  // Add custom styles to the NYPL Icon
-  const ChakraIcon = chakra(Icon, {
-    baseStyle: {
-      height: '100%',
-    },
-  });
 
   return (
     <Flex
@@ -46,32 +55,7 @@ export default function Header(props: HeaderProps): React.ReactElement {
       borderColor="gray.100"
       bgColor={mainBgColor}
     >
-      {headerLeft ? (
-        headerLeft
-      ) : (
-        <Link
-          href="https://www.nypl.org"
-          aria-label="Return to NYPL"
-          tabIndex={0}
-          fontSize={0}
-          py={1}
-          textTransform="uppercase"
-          d="flex"
-          color={linkColor}
-          height="100%"
-          alignItems="center"
-          _hover={{
-            textDecoration: 'none',
-          }}
-        >
-          <ChakraIcon
-            decorative
-            name={LogoNames.logo_nypl}
-            modifiers={['xlarge']}
-          />
-          <Text variant="headerNav">Return to NYPL</Text>
-        </Link>
-      )}
+      {headerLeft ?? <DefaultHeaderLeft />}
       <HStack ml="auto" spacing={1}>
         <TableOfContent
           navigator={navigator}

--- a/src/ui/manager.tsx
+++ b/src/ui/manager.tsx
@@ -5,7 +5,7 @@ import {
   IconRotationTypes,
 } from '@nypl/design-system-react-components';
 import * as React from 'react';
-import { ReaderReturn } from '../types';
+import { ReaderManagerArguments, ReaderReturn } from '../types';
 import Header from './Header';
 import useColorModeValue from './hooks/useColorModeValue';
 import PageButton from './PageButton';
@@ -16,7 +16,7 @@ import { getTheme } from './theme';
  * that can be imported and used separately or in a customized setup.
  * It takes the return value of useWebReader as props
  */
-const ManagerUI: React.FC<ReaderReturn> = (props) => {
+const ManagerUI: React.FC<ReaderReturn & ReaderManagerArguments> = (props) => {
   return (
     <ThemeProvider theme={getTheme(props.state?.colorMode ?? 'day')}>
       <WebReaderContent {...props} />
@@ -24,11 +24,15 @@ const ManagerUI: React.FC<ReaderReturn> = (props) => {
   );
 };
 
-const WebReaderContent: React.FC<ReaderReturn> = ({ children, ...props }) => {
+const WebReaderContent: React.FC<ReaderReturn & ReaderManagerArguments> = ({
+  children,
+  headerLeft,
+  ...props
+}) => {
   const bgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
   return (
     <Flex flexDir="column" minHeight="100vh" w="100vw">
-      {!props.isLoading && <Header {...props} />}
+      {!props.isLoading && <Header headerLeft={headerLeft} {...props} />}
       <PageButton
         onClick={props.navigator?.goBackward}
         left={0}

--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -7,13 +7,12 @@ test('render header bar', () => {
   render(<Header {...MockHtmlReaderProps} />);
 
   expect(
-    screen.getByRole('link', { name: 'Return to NYPL' })
+    screen.getByRole('link', { name: 'Return to Homepage' })
   ).toBeInTheDocument();
 
-  expect(screen.getByRole('link', { name: 'Return to NYPL' })).toHaveAttribute(
-    'href',
-    'https://www.nypl.org'
-  );
+  expect(
+    screen.getByRole('link', { name: 'Return to Homepage' })
+  ).toHaveAttribute('href', '/');
 
   expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
 


### PR DESCRIPTION
This PR adds an additional prop to the WebReader component as an optional setting to add your own back button or logo.

- Updated default back button to always return to the homepage
- Added `headerLeft` prop to the WebReader component