### PR TITLE
WIP: (for discussion) allow overriding injectables

### DIFF
--- a/src/HtmlReader/index.tsx
+++ b/src/HtmlReader/index.tsx
@@ -1,6 +1,6 @@
 import D2Reader from '@d-i-t-a/reader';
 import React from 'react';
-import injectables from './injectables';
+import defaultInjectables from './injectables';
 import {
   ColorMode,
   HtmlReaderState,
@@ -74,7 +74,13 @@ function htmlReducer(state: HtmlState, action: HtmlAction): HtmlState {
 const FONT_SIZE_STEP = 4;
 
 export default function useHtmlReader(args: ReaderArguments): ReaderReturn {
-  const { webpubManifestUrl, manifest, getContent } = args ?? {};
+  const {
+    webpubManifestUrl,
+    manifest,
+    injectables,
+    injectablesFixed,
+    getContent,
+  } = args ?? {};
   const [state, dispatch] = React.useReducer(htmlReducer, {
     colorMode: 'day',
     isScrolling: false,
@@ -94,8 +100,8 @@ export default function useHtmlReader(args: ReaderArguments): ReaderReturn {
 
     D2Reader.build({
       url,
-      injectables: injectables,
-      injectablesFixed: [],
+      injectables: injectables || defaultInjectables,
+      injectablesFixed: injectablesFixed || [],
       attributes: {
         navHeight: HEADER_HEIGHT,
         margin: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@d-i-t-a/reader/dist/types/navigator/IFrameNavigator';
 import { WebpubManifest } from './WebpubManifestTypes/WebpubManifest';
 
 export { WebpubManifest };
@@ -85,6 +86,8 @@ export type ReaderManagerArguments = {
 };
 
 export type UseWebReaderArguments = {
+  injectables?: Array<Injectable>;
+  injectablesFixed?: Array<Injectable>;
   webpubManifestUrl: string;
   proxyUrl?: string;
   getContent?: GetContent;

--- a/src/useWebReader.tsx
+++ b/src/useWebReader.tsx
@@ -41,7 +41,14 @@ function getReaderType(conformsTo: ConformsTo | null | undefined) {
 export default function useWebReader(
   args: UseWebReaderArguments
 ): HTMLActiveReader | PDFActiveReader | LoadingReader {
-  const { webpubManifestUrl, getContent, proxyUrl, pdfWorkerSrc } = args;
+  const {
+    webpubManifestUrl,
+    getContent,
+    proxyUrl,
+    pdfWorkerSrc,
+    injectables,
+    injectablesFixed,
+  } = args;
   const [manifest, setManifest] = React.useState<WebpubManifest | null>(null);
   const readerType = getReaderType(
     manifest ? manifest.metadata.conformsTo : null
@@ -57,6 +64,8 @@ export default function useWebReader(
       ? {
           webpubManifestUrl,
           manifest,
+          injectables,
+          injectablesFixed,
           getContent,
         }
       : undefined


### PR DESCRIPTION
Currently you *must* (*) inject ReadiumCSS-after.css, ReadiumCSS-before.css, and
ReadiumCSS-default.css and they *must* be available at
your.site/css/XXX.css. The same is true of opendyslexic.css at
your.site/fonts/opendyslexic. It doesn't appear that any other files can
be injected, meaning it is impossible to extend the underlying reader
functionality.

This PR allows for the overriding of these values, and also injecting
`injectablesFixed`. This is the "cheap" option, though it means that
there are now quite a few type-specific props that are included in the
common `UseWebReaderArguments`, which is probably not ideal.

Feedback is requested before embarking on tests, etc.

(*) it appears it actually will "work" if rubbish is returned, as long
as the server responds with a 200. If the server responds with a 404, it
appears to fail