### PR TITLE
Add aria-label to radio buttons

### DIFF
--- a/src/ui/HtmlSettings.tsx
+++ b/src/ui/HtmlSettings.tsx
@@ -5,7 +5,7 @@ import Button from './Button';
 import ToggleButton from './ToggleButton';
 import ToggleGroup from './ToggleGroup';
 
-type HtmlSettingsProps = {
+export type HtmlSettingsProps = {
   navigator: HtmlNavigator;
   readerState: HtmlReaderState;
   paginationValue: string;
@@ -31,10 +31,18 @@ export default function HtmlSettings(
         label="text font options"
         onChange={setFontFamily}
       >
-        <ToggleButton value="publisher">Publisher</ToggleButton>
-        <ToggleButton value="serif">Serif</ToggleButton>
-        <ToggleButton value="sans-serif">Sans-Serif</ToggleButton>
-        <ToggleButton value="open-dyslexic">Dyslexia-Friendly</ToggleButton>
+        <ToggleButton value="publisher" label="Publisher">
+          Publisher
+        </ToggleButton>
+        <ToggleButton value="serif" label="Serif">
+          Serif
+        </ToggleButton>
+        <ToggleButton value="sans-serif" label="Sans-Serif">
+          Sans-Serif
+        </ToggleButton>
+        <ToggleButton value="open-dyslexic" label="Dyslexia-Friendly">
+          Dyslexia-Friendly
+        </ToggleButton>
       </ToggleGroup>
       <ButtonGroup d="flex" spacing={0}>
         <Button
@@ -62,6 +70,7 @@ export default function HtmlSettings(
         <ToggleButton
           colorMode="day"
           value="day"
+          label="Day"
           _checked={{ bg: 'ui.white' }} // default _checked color is green for toggles
         >
           Day
@@ -69,6 +78,7 @@ export default function HtmlSettings(
         <ToggleButton
           colorMode="sepia"
           value="sepia"
+          label="Sepia"
           bg="ui.sepia" // distinct case where default needs to be sepia
           _active={{ bg: 'ui.sepia' }}
           _hover={{ bg: 'ui.sepia' }}
@@ -79,6 +89,7 @@ export default function HtmlSettings(
         <ToggleButton
           colorMode="night"
           value="night"
+          label="Night"
           _checked={{ bg: 'ui.black' }}
         >
           Night
@@ -89,8 +100,12 @@ export default function HtmlSettings(
         value={paginationValue}
         label="pagination options"
       >
-        <ToggleButton value="paginated">Paginated</ToggleButton>
-        <ToggleButton value="scrolling">Scrolling</ToggleButton>
+        <ToggleButton value="paginated" label="Paginated">
+          Paginated
+        </ToggleButton>
+        <ToggleButton value="scrolling" label="Scrolling">
+          Scrolling
+        </ToggleButton>
       </ToggleGroup>
     </>
   );

--- a/src/ui/PdfSettings.tsx
+++ b/src/ui/PdfSettings.tsx
@@ -6,7 +6,7 @@ import Button from './Button';
 import ToggleButton from './ToggleButton';
 import ToggleGroup from './ToggleGroup';
 
-type PdfSettingsProps = {
+export type PdfSettingsProps = {
   navigator: PdfNavigator;
   readerState: PdfReaderState;
   paginationValue: string;
@@ -61,8 +61,12 @@ export default function PdfSettings(
         value={paginationValue}
         label="pagination options"
       >
-        <ToggleButton value="paginated">Paginated</ToggleButton>
-        <ToggleButton value="scrolling">Scrolling</ToggleButton>
+        <ToggleButton value="paginated" label="Paginated">
+          Paginated
+        </ToggleButton>
+        <ToggleButton value="scrolling" label="Scrolling">
+          Scrolling
+        </ToggleButton>
       </ToggleGroup>
     </>
   );

--- a/src/ui/ToggleButton.tsx
+++ b/src/ui/ToggleButton.tsx
@@ -16,13 +16,14 @@ export interface ToggleButtonProps
   extends React.ComponentPropsWithoutRef<typeof ChakraBox> {
   isChecked?: false;
   colorMode?: ColorMode;
+  label?: string;
   value: string;
 }
 
 function ToggleButton(
   props: React.PropsWithoutRef<ToggleButtonProps>
 ): React.ReactElement {
-  const { isChecked, children, colorMode, ...rest } = props;
+  const { isChecked, children, colorMode, label, ...rest } = props;
   const { getInputProps, getCheckboxProps } = useRadio(props);
 
   const input = getInputProps();
@@ -32,7 +33,7 @@ function ToggleButton(
   return (
     // This will override the default theme if we specify the colorMode to the toggle button.
     <ThemeProvider theme={getTheme(colorMode ?? theme.currentColorMode)}>
-      <ChakraBox as="label" d="flex" flexGrow={1}>
+      <ChakraBox as="label" d="flex" flexGrow={1} aria-label={label}>
         <input {...input} />
         <Button as="div" {...checkbox} variant="toggle" {...rest} flexGrow={1}>
           {children}

--- a/tests/SettingsCard.test.tsx
+++ b/tests/SettingsCard.test.tsx
@@ -1,36 +1,41 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import SettingsCard from '../src/ui/SettingsButton';
-import { MockHtmlReaderProps, MockPdfReaderProps } from './utils/MockData';
+import { MockHtmlSettingsProps, MockPdfSettingsProps } from './utils/MockData';
+import HtmlSettings from '../src/ui/HtmlSettings';
+import PdfSettings from '../src/ui/PdfSettings';
 
 describe('Render settings for different media type', () => {
   test('HTML settings', () => {
-    const { getByRole, getByLabelText, queryByLabelText } = render(
-      <SettingsCard {...MockHtmlReaderProps} />
+    const { getByRole, queryByLabelText } = render(
+      <HtmlSettings {...MockHtmlSettingsProps} />
     );
 
-    expect(getByRole('button', { name: 'Settings' })).toBeInTheDocument();
-
     // default buttons
-    expect(getByLabelText('Publisher')).toBeInTheDocument();
-    expect(getByLabelText('Serif')).toBeInTheDocument();
-    expect(getByLabelText('Sans-Serif')).toBeInTheDocument();
-    expect(getByLabelText('Dyslexia-Friendly')).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Publisher' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Serif' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Sans-Serif' })).toBeInTheDocument();
+    expect(
+      getByRole('radio', { name: 'Dyslexia-Friendly' })
+    ).toBeInTheDocument();
 
-    expect(getByLabelText('Decrease font size')).toBeInTheDocument();
-    expect(getByLabelText('Increase font size')).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: 'Decrease font size' })
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: 'Increase font size' })
+    ).toBeInTheDocument();
 
-    expect(getByLabelText('Day')).toBeInTheDocument();
-    expect(getByLabelText('Sepia')).toBeInTheDocument();
-    expect(getByLabelText('Night')).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Day' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Sepia' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Night' })).toBeInTheDocument();
 
-    expect(getByLabelText('Paginated')).toBeInTheDocument();
-    expect(getByLabelText('Scrolling')).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Paginated' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Scrolling' })).toBeInTheDocument();
 
     // default checked buttons. Can't mock 'click' because it's controlled.
-    expect(getByLabelText('Sans-Serif')).toBeChecked();
-    expect(getByLabelText('Day')).toBeChecked();
-    expect(getByLabelText('Paginated')).toBeChecked();
+    expect(getByRole('radio', { name: 'Sans-Serif' })).toBeChecked();
+    expect(getByRole('radio', { name: 'Day' })).toBeChecked();
+    expect(getByRole('radio', { name: 'Paginated' })).toBeChecked();
 
     // TODO: pdf specific tests, create tests for PDF specific settings and make sure they don't
     // show up for the HTML reader. This should also apply to Cypress tests.
@@ -39,22 +44,18 @@ describe('Render settings for different media type', () => {
   });
 
   test('PDF settings', () => {
-    const { getByRole, getByLabelText } = render(
-      <SettingsCard {...MockPdfReaderProps} />
-    );
+    const { getByRole } = render(<PdfSettings {...MockPdfSettingsProps} />);
 
     // TODO: Need to figure out what settings to be shown by default
 
-    expect(getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Paginated' })).toBeInTheDocument();
+    expect(getByRole('radio', { name: 'Scrolling' })).toBeInTheDocument();
 
-    expect(getByLabelText('Paginated')).toBeInTheDocument();
-    expect(getByLabelText('Scrolling')).toBeInTheDocument();
-
-    expect(getByLabelText('Zoom In')).toBeInTheDocument();
-    expect(getByLabelText('Zoom Out')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Zoom In' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Zoom Out' })).toBeInTheDocument();
 
     // default checked values
-    expect(getByLabelText('Paginated')).toBeChecked();
+    expect(getByRole('radio', { name: 'Paginated' })).toBeChecked();
 
     // TODO: HTML specific tests. Same as above, make sure HTML settings/buttons do not show up on the page when a PDF is being rendered.
   });

--- a/tests/ToggleButton.test.tsx
+++ b/tests/ToggleButton.test.tsx
@@ -4,8 +4,8 @@ import ToggleButton from '../src/ui/ToggleButton';
 
 describe('ToggleButton', () => {
   test('Button does not show checkmark if isChecked=false', () => {
-    render(<ToggleButton>hello</ToggleButton>);
-    expect(screen.getByLabelText('hello')).not.toBeChecked();
+    render(<ToggleButton label="hello">hello</ToggleButton>);
+    expect(screen.getByRole('radio', { name: 'hello' })).not.toBeChecked();
   });
   //   test('Button shows checkmark if is isChecked=true', () => {});
 });

--- a/tests/ToggleGroup.test.tsx
+++ b/tests/ToggleGroup.test.tsx
@@ -6,9 +6,15 @@ import ToggleGroup from '../src/ui/ToggleGroup';
 const renderComponent = () => {
   return render(
     <ToggleGroup value="sedona" label="test">
-      <ToggleButton value="sedona">Sedona</ToggleButton>
-      <ToggleButton value="santa_fe">Santa Fe</ToggleButton>
-      <ToggleButton value="las_cruces">Las Cruces</ToggleButton>
+      <ToggleButton value="sedona" label="Sedona">
+        Sedona
+      </ToggleButton>
+      <ToggleButton value="santa_fe" label="Santa Fe">
+        Santa Fe
+      </ToggleButton>
+      <ToggleButton value="las_cruces" label="Las Cruces">
+        Las Cruces
+      </ToggleButton>
     </ToggleGroup>
   );
 };
@@ -24,26 +30,32 @@ test('toggle group should contain all radio buttons', () => {
 });
 
 test('respect value props', () => {
-  const { getByLabelText } = renderComponent();
+  const { getByRole } = renderComponent();
 
-  expect(getByLabelText('Sedona')).toBeChecked();
+  expect(getByRole('radio', { name: /sedona/i })).toBeChecked();
 
-  fireEvent.click(getByLabelText('Santa Fe'));
+  fireEvent.click(getByRole('radio', { name: /santa Fe/i }));
 
-  expect(getByLabelText('Sedona')).toBeChecked();
+  expect(getByRole('radio', { name: /sedona/i })).toBeChecked();
 });
 
 test('onChange callback function should be called', () => {
   const onChangeHandler = jest.fn();
-  const { getByLabelText } = render(
+  const { getByRole } = render(
     <ToggleGroup value="sedona" onChange={onChangeHandler} label="test">
-      <ToggleButton value="sedona">Sedona</ToggleButton>
-      <ToggleButton value="santa_fe">Santa Fe</ToggleButton>
-      <ToggleButton value="las_cruces">Las Cruces</ToggleButton>
+      <ToggleButton value="sedona" label="Sedona">
+        Sedona
+      </ToggleButton>
+      <ToggleButton value="santa_fe" label="Santa Fe">
+        Santa Fe
+      </ToggleButton>
+      <ToggleButton value="las_cruces" label="Las Cruces">
+        Las Cruces
+      </ToggleButton>
     </ToggleGroup>
   );
 
-  fireEvent.click(getByLabelText('Santa Fe'));
+  fireEvent.click(getByRole('radio', { name: /santa fe/i }));
 
   expect(onChangeHandler).toHaveBeenCalledWith('santa_fe');
 });

--- a/tests/utils/MockData.tsx
+++ b/tests/utils/MockData.tsx
@@ -7,6 +7,8 @@ import {
   ReaderState,
   WebpubManifest,
 } from '../../src/types';
+import { HtmlSettingsProps } from '../../src/ui/HtmlSettings';
+import { PdfSettingsProps } from '../../src/ui/PdfSettings';
 
 const goForwardFn = jest.fn();
 const goBackwardFn = jest.fn();
@@ -167,6 +169,18 @@ const MockPdfReaderState = {
   numPages: null,
   currentTocUrl: null,
 };
+
+export const MockHtmlSettingsProps = {
+  navigator: MockHtmlNavigator,
+  readerState: MockHtmlReaderState,
+  paginationValue: 'paginated',
+} as HtmlSettingsProps;
+
+export const MockPdfSettingsProps = {
+  navigator: MockPdfNavigator,
+  readerState: MockPdfReaderState,
+  paginationValue: 'paginated',
+} as PdfSettingsProps;
 
 export const MockHtmlReaderProps = {
   type: 'HTML',


### PR DESCRIPTION
This PR adds aria-label to the radio buttons because we were not able to access these elements by their labels, mostly due to the fact that we have a nested `div` inside the label element, making the accessibility name to be null when using APIs like `getByRole`.


- Added aria-label to the ToggleButton component
- Updated Settings card tests