### PR TITLE
Update webreader icons

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,7 +1,6 @@
 const React = require('react');
 const { ChakraProvider } = require('@chakra-ui/react');
 import { getTheme } from '../src/ui/theme';
-import '@nypl/design-system-react-components/dist/styles.css';
 
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -10,7 +10,6 @@ import {
   useParams,
 } from 'react-router-dom';
 import WebReader from '../src';
-import '@nypl/design-system-react-components/dist/styles.css';
 import {
   ChakraProvider,
   Heading,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "comlink": "^4.3.1",
         "framer-motion": "^4.1.6",
         "node-fetch": "^2.6.1",
+        "react-icons": "^4.3.1",
         "react-pdf": "^5.3.2",
         "workbox-expiration": "^6.2.4",
         "workbox-precaching": "^6.2.4",
@@ -28945,6 +28946,14 @@
         "react-dom": "^16.6.0 || ^17.0.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-inspector": {
       "version": "5.1.1",
       "integrity": "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==",
@@ -56789,6 +56798,12 @@
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
       }
+    },
+    "react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "requires": {}
     },
     "react-inspector": {
       "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@d-i-t-a/reader": "2.0.0-alpha.7",
         "@emotion/react": "^11.4.0",
         "@emotion/styled": "^11.3.0",
-        "@nypl/design-system-react-components": "^0.21.2",
         "comlink": "^4.3.1",
         "framer-motion": "^4.1.6",
         "node-fetch": "^2.6.1",
@@ -4562,6 +4561,7 @@
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
       "dependencies": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
@@ -4647,42 +4647,6 @@
         "@types/pako": "^1.0.1",
         "node-fetch": "^2.6.1",
         "pako": "^1.0.11"
-      }
-    },
-    "node_modules/@nypl/design-system-react-components": {
-      "version": "0.21.2",
-      "integrity": "sha512-QtE9wCq7nNo/LiKvnyhGSgiNmIXAcrmi7G0r7VXRQshtOz0rvd0c7a6kbvSYT9WHtxJoB7g2uRouakB7KzJy9A==",
-      "dependencies": {
-        "cpy-cli": "^3.1.1",
-        "he": "^1.2.0",
-        "react": "^16.13.1",
-        "react-router-dom": "^5.2.0",
-        "react-uid": "^2.3.0",
-        "system-font-css": "^2.0.2",
-        "typescript": "^3.9.2"
-      }
-    },
-    "node_modules/@nypl/design-system-react-components/node_modules/react": {
-      "version": "16.14.0",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@nypl/design-system-react-components/node_modules/typescript": {
-      "version": "3.9.10",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -10295,6 +10259,7 @@
     "node_modules/@types/glob": {
       "version": "7.1.4",
       "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "dev": true,
       "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -10441,15 +10406,13 @@
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
-    "node_modules/@types/minimist": {
-      "version": "1.2.2",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "14.17.17",
-      "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ=="
+      "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -10462,7 +10425,8 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
     },
     "node_modules/@types/npmlog": {
       "version": "4.1.3",
@@ -11149,6 +11113,7 @@
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -11513,6 +11478,7 @@
     "node_modules/array-uniq": {
       "version": "1.0.3",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11578,6 +11544,7 @@
     "node_modules/arrify": {
       "version": "2.0.1",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13038,7 +13005,8 @@
     },
     "node_modules/call-me-maybe": {
       "version": "1.0.1",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -13059,6 +13027,7 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13069,21 +13038,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/can-use-dom": {
@@ -13385,6 +13339,7 @@
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13938,6 +13893,7 @@
     "node_modules/cp-file": {
       "version": "7.0.0",
       "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "make-dir": "^3.0.0",
@@ -13951,6 +13907,7 @@
     "node_modules/cp-file/node_modules/make-dir": {
       "version": "3.1.0",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -13961,42 +13918,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cpr": {
-      "version": "2.2.0",
-      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "minimist": "^1.2.0",
-        "mkdirp": "~0.5.1",
-        "rimraf": "^2.5.4"
-      },
-      "bin": {
-        "cpr": "bin/cpr"
-      }
-    },
-    "node_modules/cpr/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/cpr/node_modules/rimraf": {
-      "version": "2.7.1",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/cpy": {
       "version": "8.1.2",
       "integrity": "sha512-dmC4mUesv0OYH2kNFEidtf/skUwv4zePmGeepjyyJ0qTo5+8KhA1o99oIAwVVLzQMAeDJml74d6wPPKb6EZUTg==",
+      "dev": true,
       "dependencies": {
         "arrify": "^2.0.1",
         "cp-file": "^7.0.0",
@@ -14015,26 +13940,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cpy-cli": {
-      "version": "3.1.1",
-      "integrity": "sha512-HCpNdBkQy3rw+uARLuIf0YurqsMXYzBa9ihhSAuxYJcNIrqrSq3BstPfr0cQN38AdMrQiO9Dp4hYy7GtGJsLPg==",
-      "dependencies": {
-        "cpy": "^8.0.0",
-        "meow": "^6.1.1"
-      },
-      "bin": {
-        "cpy": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cpy/node_modules/@nodelib/fs.stat": {
       "version": "1.1.3",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -14042,6 +13951,7 @@
     "node_modules/cpy/node_modules/array-union": {
       "version": "1.0.2",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
       "dependencies": {
         "array-uniq": "^1.0.1"
       },
@@ -14052,6 +13962,7 @@
     "node_modules/cpy/node_modules/braces": {
       "version": "2.3.2",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
       "dependencies": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -14071,6 +13982,7 @@
     "node_modules/cpy/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -14081,6 +13993,7 @@
     "node_modules/cpy/node_modules/dir-glob": {
       "version": "2.2.2",
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
       "dependencies": {
         "path-type": "^3.0.0"
       },
@@ -14091,6 +14004,7 @@
     "node_modules/cpy/node_modules/fast-glob": {
       "version": "2.2.7",
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
       "dependencies": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
@@ -14106,6 +14020,7 @@
     "node_modules/cpy/node_modules/fill-range": {
       "version": "4.0.0",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -14119,6 +14034,7 @@
     "node_modules/cpy/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -14129,6 +14045,7 @@
     "node_modules/cpy/node_modules/glob-parent": {
       "version": "3.1.0",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -14137,6 +14054,7 @@
     "node_modules/cpy/node_modules/glob-parent/node_modules/is-glob": {
       "version": "3.1.0",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
       },
@@ -14147,6 +14065,7 @@
     "node_modules/cpy/node_modules/globby": {
       "version": "9.2.0",
       "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "dev": true,
       "dependencies": {
         "@types/glob": "^7.1.1",
         "array-union": "^1.0.2",
@@ -14163,11 +14082,13 @@
     },
     "node_modules/cpy/node_modules/is-buffer": {
       "version": "1.1.6",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/cpy/node_modules/is-extendable": {
       "version": "0.1.1",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14175,6 +14096,7 @@
     "node_modules/cpy/node_modules/is-number": {
       "version": "3.0.0",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -14185,6 +14107,7 @@
     "node_modules/cpy/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -14195,6 +14118,7 @@
     "node_modules/cpy/node_modules/micromatch": {
       "version": "3.1.10",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -14217,6 +14141,7 @@
     "node_modules/cpy/node_modules/path-type": {
       "version": "3.0.0",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -14227,6 +14152,7 @@
     "node_modules/cpy/node_modules/path-type/node_modules/pify": {
       "version": "3.0.0",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14234,6 +14160,7 @@
     "node_modules/cpy/node_modules/pify": {
       "version": "4.0.1",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14241,6 +14168,7 @@
     "node_modules/cpy/node_modules/slash": {
       "version": "2.0.0",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14248,6 +14176,7 @@
     "node_modules/cpy/node_modules/to-regex-range": {
       "version": "2.1.1",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -14759,31 +14688,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.0",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -18219,7 +18123,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.3.0",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "node_modules/global": {
       "version": "4.4.0",
@@ -18420,13 +18325,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
@@ -18473,6 +18371,7 @@
     "node_modules/has-glob": {
       "version": "1.0.0",
       "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+      "dev": true,
       "dependencies": {
         "is-glob": "^3.0.0"
       },
@@ -18483,6 +18382,7 @@
     "node_modules/has-glob/node_modules/is-glob": {
       "version": "3.1.0",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
       },
@@ -18733,6 +18633,7 @@
     "node_modules/he": {
       "version": "1.2.0",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -18752,6 +18653,7 @@
     "node_modules/history": {
       "version": "4.10.1",
       "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -18783,7 +18685,8 @@
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -19672,6 +19575,7 @@
     "node_modules/ignore": {
       "version": "4.0.6",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -19833,6 +19737,7 @@
     "node_modules/indent-string": {
       "version": "4.0.0",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -20222,6 +20127,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20263,6 +20169,7 @@
     "node_modules/is-glob": {
       "version": "4.0.1",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -20405,13 +20312,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -24376,6 +24276,7 @@
     "node_modules/junk": {
       "version": "3.1.0",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -25095,16 +24996,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/map-obj": {
-      "version": "4.2.1",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
@@ -25276,39 +25167,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "node_modules/meow": {
-      "version": "6.1.1",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.13.1",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-class-names": {
       "version": "1.4.2",
       "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==",
@@ -25333,6 +25191,7 @@
     "node_modules/merge2": {
       "version": "1.4.1",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -25440,6 +25299,7 @@
     "node_modules/min-indent": {
       "version": "1.0.1",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -25447,6 +25307,7 @@
     "node_modules/mini-create-react-context": {
       "version": "0.4.1",
       "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "tiny-warning": "^1.0.3"
@@ -25477,25 +25338,6 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/minimist-options/node_modules/arrify": {
-      "version": "1.0.1",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/minipass": {
       "version": "3.1.5",
@@ -25732,7 +25574,8 @@
     },
     "node_modules/nested-error-stacks": {
       "version": "2.1.0",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
     },
     "node_modules/nested-object-assign": {
       "version": "1.0.4",
@@ -25970,6 +25813,7 @@
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -25980,6 +25824,7 @@
     "node_modules/normalize-package-data/node_modules/semver": {
       "version": "5.7.1",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -26486,6 +26331,7 @@
     "node_modules/p-all": {
       "version": "2.1.0",
       "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "dev": true,
       "dependencies": {
         "p-map": "^2.0.0"
       },
@@ -26496,6 +26342,7 @@
     "node_modules/p-all/node_modules/p-map": {
       "version": "2.1.0",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -26522,6 +26369,7 @@
     "node_modules/p-event": {
       "version": "4.2.0",
       "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
       "dependencies": {
         "p-timeout": "^3.1.0"
       },
@@ -26535,6 +26383,7 @@
     "node_modules/p-filter": {
       "version": "2.1.0",
       "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
       "dependencies": {
         "p-map": "^2.0.0"
       },
@@ -26545,6 +26394,7 @@
     "node_modules/p-filter/node_modules/p-map": {
       "version": "2.1.0",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -26552,6 +26402,7 @@
     "node_modules/p-finally": {
       "version": "1.0.0",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -26587,6 +26438,7 @@
     "node_modules/p-map": {
       "version": "3.0.0",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -26597,6 +26449,7 @@
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -27043,11 +26896,13 @@
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "devOptional": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -28148,13 +28003,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/r2-lcp-js": {
       "version": "1.0.32",
       "integrity": "sha512-cNpOc9ZWatCe7WPMQxVfA7p1xtynrU7eWZ/Cw41+zkKRUsOU4b+CTtwq1APMut+dMhnEHNIjDVUqxGBnFUa7dw==",
@@ -29096,6 +28944,7 @@
     "node_modules/react-router": {
       "version": "5.2.1",
       "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29115,6 +28964,7 @@
     "node_modules/react-router-dom": {
       "version": "5.3.0",
       "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29130,18 +28980,21 @@
     },
     "node_modules/react-router/node_modules/isarray": {
       "version": "0.0.1",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/react-router/node_modules/path-to-regexp": {
       "version": "1.8.0",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
     },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.14.1",
@@ -29245,32 +29098,10 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/react-uid": {
-      "version": "2.3.1",
-      "integrity": "sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-uid/node_modules/tslib": {
-      "version": "1.14.1",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
@@ -29284,6 +29115,7 @@
     "node_modules/read-pkg-up": {
       "version": "7.0.1",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
       "dependencies": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
@@ -29299,6 +29131,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "4.1.0",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -29310,6 +29143,7 @@
     "node_modules/read-pkg-up/node_modules/locate-path": {
       "version": "5.0.0",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -29320,6 +29154,7 @@
     "node_modules/read-pkg-up/node_modules/p-limit": {
       "version": "2.3.0",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -29333,6 +29168,7 @@
     "node_modules/read-pkg-up/node_modules/p-locate": {
       "version": "4.1.0",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -29343,6 +29179,7 @@
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -29407,6 +29244,7 @@
     "node_modules/redent": {
       "version": "3.0.0",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -30125,7 +29963,8 @@
     },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "dev": true
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -31256,6 +31095,7 @@
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -31263,11 +31103,13 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -31275,7 +31117,8 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.10",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+      "dev": true
     },
     "node_modules/specificity": {
       "version": "0.4.1",
@@ -31863,6 +31706,7 @@
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -31990,17 +31834,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/system-font-css": {
-      "version": "2.0.2",
-      "integrity": "sha512-zK36lpja4NIi4Po99bXReeqeDcM1sW4hTKJt5Mby/IXX6kLSwjkQ4pZThFdgb/jDwfRsBvxxVG+VekP1sTdF0w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "cpr": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/ta-json-x": {
@@ -32451,7 +32284,8 @@
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "dev": true
     },
     "node_modules/tinycolor2": {
       "version": "1.4.2",
@@ -32603,13 +32437,6 @@
       "version": "0.0.1",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
-    },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/trim-trailing-lines": {
       "version": "1.1.4",
@@ -32959,6 +32786,7 @@
     "node_modules/type-fest": {
       "version": "0.8.1",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -34137,6 +33965,7 @@
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -34144,7 +33973,8 @@
     },
     "node_modules/value-equal": {
       "version": "1.0.1",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -35372,17 +35202,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
@@ -38660,6 +38479,7 @@
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
@@ -38725,34 +38545,6 @@
         "@types/pako": "^1.0.1",
         "node-fetch": "^2.6.1",
         "pako": "^1.0.11"
-      }
-    },
-    "@nypl/design-system-react-components": {
-      "version": "0.21.2",
-      "integrity": "sha512-QtE9wCq7nNo/LiKvnyhGSgiNmIXAcrmi7G0r7VXRQshtOz0rvd0c7a6kbvSYT9WHtxJoB7g2uRouakB7KzJy9A==",
-      "requires": {
-        "cpy-cli": "^3.1.1",
-        "he": "^1.2.0",
-        "react": "^16.13.1",
-        "react-router-dom": "^5.2.0",
-        "react-uid": "^2.3.0",
-        "system-font-css": "^2.0.2",
-        "typescript": "^3.9.2"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "typescript": {
-          "version": "3.9.10",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
-        }
       }
     },
     "@octokit/auth-token": {
@@ -42683,6 +42475,7 @@
     "@types/glob": {
       "version": "7.1.4",
       "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "dev": true,
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -42829,15 +42622,13 @@
     },
     "@types/minimatch": {
       "version": "3.0.5",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
-    "@types/minimist": {
-      "version": "1.2.2",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "@types/node": {
       "version": "14.17.17",
-      "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ=="
+      "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -42850,7 +42641,8 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
     },
     "@types/npmlog": {
       "version": "4.1.3",
@@ -43432,6 +43224,7 @@
     "aggregate-error": {
       "version": "3.1.0",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -43700,7 +43493,8 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -43741,7 +43535,8 @@
     },
     "arrify": {
       "version": "2.0.1",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -44876,7 +44671,8 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -44893,21 +44689,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-css": {
       "version": "2.0.1",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "dev": true
-    },
-    "camelcase-keys": {
-      "version": "6.2.2",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      }
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -45135,7 +44923,8 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -45566,6 +45355,7 @@
     "cp-file": {
       "version": "7.0.0",
       "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "make-dir": "^3.0.0",
@@ -45576,34 +45366,9 @@
         "make-dir": {
           "version": "3.1.0",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
           "requires": {
             "semver": "^6.0.0"
-          }
-        }
-      }
-    },
-    "cpr": {
-      "version": "2.2.0",
-      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
-      "requires": {
-        "graceful-fs": "^4.1.5",
-        "minimist": "^1.2.0",
-        "mkdirp": "~0.5.1",
-        "rimraf": "^2.5.4"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
           }
         }
       }
@@ -45611,6 +45376,7 @@
     "cpy": {
       "version": "8.1.2",
       "integrity": "sha512-dmC4mUesv0OYH2kNFEidtf/skUwv4zePmGeepjyyJ0qTo5+8KhA1o99oIAwVVLzQMAeDJml74d6wPPKb6EZUTg==",
+      "dev": true,
       "requires": {
         "arrify": "^2.0.1",
         "cp-file": "^7.0.0",
@@ -45625,11 +45391,13 @@
       "dependencies": {
         "@nodelib/fs.stat": {
           "version": "1.1.3",
-          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
         },
         "array-union": {
           "version": "1.0.2",
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
           "requires": {
             "array-uniq": "^1.0.1"
           }
@@ -45637,6 +45405,7 @@
         "braces": {
           "version": "2.3.2",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -45653,6 +45422,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -45662,6 +45432,7 @@
         "dir-glob": {
           "version": "2.2.2",
           "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+          "dev": true,
           "requires": {
             "path-type": "^3.0.0"
           }
@@ -45669,6 +45440,7 @@
         "fast-glob": {
           "version": "2.2.7",
           "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
             "@nodelib/fs.stat": "^1.1.2",
@@ -45681,6 +45453,7 @@
         "fill-range": {
           "version": "4.0.0",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -45691,6 +45464,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -45700,6 +45474,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -45708,6 +45483,7 @@
             "is-glob": {
               "version": "3.1.0",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
               "requires": {
                 "is-extglob": "^2.1.0"
               }
@@ -45717,6 +45493,7 @@
         "globby": {
           "version": "9.2.0",
           "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+          "dev": true,
           "requires": {
             "@types/glob": "^7.1.1",
             "array-union": "^1.0.2",
@@ -45730,15 +45507,18 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
         },
         "is-extendable": {
           "version": "0.1.1",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "dev": true
         },
         "is-number": {
           "version": "3.0.0",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -45746,6 +45526,7 @@
             "kind-of": {
               "version": "3.2.2",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -45755,6 +45536,7 @@
         "micromatch": {
           "version": "3.1.10",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -45774,40 +45556,37 @@
         "path-type": {
           "version": "3.0.0",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           },
           "dependencies": {
             "pify": {
               "version": "3.0.0",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
             }
           }
         },
         "pify": {
           "version": "4.0.1",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
         },
         "slash": {
           "version": "2.0.0",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
         },
         "to-regex-range": {
           "version": "2.1.1",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
         }
-      }
-    },
-    "cpy-cli": {
-      "version": "3.1.1",
-      "integrity": "sha512-HCpNdBkQy3rw+uARLuIf0YurqsMXYzBa9ihhSAuxYJcNIrqrSq3BstPfr0cQN38AdMrQiO9Dp4hYy7GtGJsLPg==",
-      "requires": {
-        "cpy": "^8.0.0",
-        "meow": "^6.1.1"
       }
     },
     "create-ecdh": {
@@ -46212,24 +45991,6 @@
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-        }
       }
     },
     "decimal.js": {
@@ -48852,7 +48613,8 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "global": {
       "version": "4.4.0",
@@ -49007,10 +48769,6 @@
         "har-schema": "^2.0.0"
       }
     },
-    "hard-rejection": {
-      "version": "2.1.0",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
-    },
     "has": {
       "version": "1.0.3",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
@@ -49044,6 +48802,7 @@
     "has-glob": {
       "version": "1.0.0",
       "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+      "dev": true,
       "requires": {
         "is-glob": "^3.0.0"
       },
@@ -49051,6 +48810,7 @@
         "is-glob": {
           "version": "3.1.0",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -49231,7 +48991,8 @@
     },
     "he": {
       "version": "1.2.0",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hey-listen": {
       "version": "1.0.8",
@@ -49245,6 +49006,7 @@
     "history": {
       "version": "4.10.1",
       "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -49278,7 +49040,8 @@
     },
     "hosted-git-info": {
       "version": "2.8.9",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -49869,7 +49632,8 @@
     },
     "ignore": {
       "version": "4.0.6",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
     },
     "image-size": {
       "version": "1.0.0",
@@ -49976,7 +49740,8 @@
     },
     "indent-string": {
       "version": "4.0.0",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -50242,7 +50007,8 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "devOptional": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -50269,6 +50035,7 @@
     "is-glob": {
       "version": "4.0.1",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -50354,10 +50121,6 @@
       "version": "3.0.3",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -53313,7 +53076,8 @@
     },
     "junk": {
       "version": "3.1.0",
-      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "dev": true
     },
     "keyv": {
       "version": "4.0.3",
@@ -53845,10 +53609,6 @@
       "version": "0.2.2",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "map-obj": {
-      "version": "4.2.1",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
-    },
     "map-or-similar": {
       "version": "1.5.0",
       "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
@@ -53980,29 +53740,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "meow": {
-      "version": "6.1.1",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
-      "requires": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.13.1",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
-        }
-      }
-    },
     "merge-class-names": {
       "version": "1.4.2",
       "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw=="
@@ -54023,7 +53760,8 @@
     },
     "merge2": {
       "version": "1.4.1",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -54101,11 +53839,13 @@
     },
     "min-indent": {
       "version": "1.0.1",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-create-react-context": {
       "version": "0.4.1",
       "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
         "tiny-warning": "^1.0.3"
@@ -54129,21 +53869,6 @@
     "minimist": {
       "version": "1.2.5",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "minimist-options": {
-      "version": "4.1.0",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        }
-      }
     },
     "minipass": {
       "version": "3.1.5",
@@ -54330,7 +54055,8 @@
     },
     "nested-error-stacks": {
       "version": "2.1.0",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
     },
     "nested-object-assign": {
       "version": "1.0.4",
@@ -54539,6 +54265,7 @@
     "normalize-package-data": {
       "version": "2.5.0",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -54548,7 +54275,8 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -54910,13 +54638,15 @@
     "p-all": {
       "version": "2.1.0",
       "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "dev": true,
       "requires": {
         "p-map": "^2.0.0"
       },
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
         }
       }
     },
@@ -54933,6 +54663,7 @@
     "p-event": {
       "version": "4.2.0",
       "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
       "requires": {
         "p-timeout": "^3.1.0"
       }
@@ -54940,19 +54671,22 @@
     "p-filter": {
       "version": "2.1.0",
       "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
       "requires": {
         "p-map": "^2.0.0"
       },
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
         }
       }
     },
     "p-finally": {
       "version": "1.0.0",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
       "version": "3.1.0",
@@ -54973,6 +54707,7 @@
     "p-map": {
       "version": "3.0.0",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -54980,6 +54715,7 @@
     "p-timeout": {
       "version": "3.2.0",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -55344,11 +55080,13 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "devOptional": true
     },
     "path-exists": {
       "version": "4.0.0",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -56181,10 +55919,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "quick-lru": {
-      "version": "4.0.1",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
-    },
     "r2-lcp-js": {
       "version": "1.0.32",
       "integrity": "sha512-cNpOc9ZWatCe7WPMQxVfA7p1xtynrU7eWZ/Cw41+zkKRUsOU4b+CTtwq1APMut+dMhnEHNIjDVUqxGBnFUa7dw==",
@@ -56904,6 +56638,7 @@
     "react-router": {
       "version": "5.2.1",
       "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -56919,24 +56654,28 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
           "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
         },
         "react-is": {
           "version": "16.13.1",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },
     "react-router-dom": {
       "version": "5.3.0",
       "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -57026,22 +56765,10 @@
         "use-latest": "^1.0.0"
       }
     },
-    "react-uid": {
-      "version": "2.3.1",
-      "integrity": "sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==",
-      "requires": {
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "read-pkg": {
       "version": "5.2.0",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
@@ -57051,13 +56778,15 @@
       "dependencies": {
         "type-fest": {
           "version": "0.6.0",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
         }
       }
     },
     "read-pkg-up": {
       "version": "7.0.1",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
       "requires": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
@@ -57067,6 +56796,7 @@
         "find-up": {
           "version": "4.1.0",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -57075,6 +56805,7 @@
         "locate-path": {
           "version": "5.0.0",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -57082,6 +56813,7 @@
         "p-limit": {
           "version": "2.3.0",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -57089,6 +56821,7 @@
         "p-locate": {
           "version": "4.1.0",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -57148,6 +56881,7 @@
     "redent": {
       "version": "3.0.0",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -57687,7 +57421,8 @@
     },
     "resolve-pathname": {
       "version": "3.0.0",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -58590,6 +58325,7 @@
     "spdx-correct": {
       "version": "3.1.1",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -58597,11 +58333,13 @@
     },
     "spdx-exceptions": {
       "version": "2.3.0",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -58609,7 +58347,8 @@
     },
     "spdx-license-ids": {
       "version": "3.0.10",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+      "dev": true
     },
     "specificity": {
       "version": "0.4.1",
@@ -59051,6 +58790,7 @@
     "strip-indent": {
       "version": "3.0.0",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
@@ -59146,13 +58886,6 @@
         "get-symbol-description": "^1.0.0",
         "has-symbols": "^1.0.2",
         "object.getownpropertydescriptors": "^2.1.2"
-      }
-    },
-    "system-font-css": {
-      "version": "2.0.2",
-      "integrity": "sha512-zK36lpja4NIi4Po99bXReeqeDcM1sW4hTKJt5Mby/IXX6kLSwjkQ4pZThFdgb/jDwfRsBvxxVG+VekP1sTdF0w==",
-      "requires": {
-        "cpr": "^2.2.0"
       }
     },
     "ta-json-x": {
@@ -59489,7 +59222,8 @@
     },
     "tiny-warning": {
       "version": "1.0.3",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "dev": true
     },
     "tinycolor2": {
       "version": "1.4.2",
@@ -59605,10 +59339,6 @@
       "version": "0.0.1",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
-    },
-    "trim-newlines": {
-      "version": "3.0.1",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-trailing-lines": {
       "version": "1.1.4",
@@ -59835,7 +59565,8 @@
     },
     "type-fest": {
       "version": "0.8.1",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -60720,6 +60451,7 @@
     "validate-npm-package-license": {
       "version": "3.0.4",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -60727,7 +60459,8 @@
     },
     "value-equal": {
       "version": "1.0.1",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -61707,14 +61440,6 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
-      }
-    },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "@d-i-t-a/reader": "2.0.0-alpha.7",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
-    "@nypl/design-system-react-components": "^0.21.2",
     "comlink": "^4.3.1",
     "framer-motion": "^4.1.6",
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "comlink": "^4.3.1",
     "framer-motion": "^4.1.6",
     "node-fetch": "^2.6.1",
+    "react-icons": "^4.3.1",
     "react-pdf": "^5.3.2",
     "workbox-expiration": "^6.2.4",
     "workbox-precaching": "^6.2.4",

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { Flex, Link, HStack, Text } from '@chakra-ui/react';
-import { Icon, IconNames } from '@nypl/design-system-react-components';
+import { Flex, Link, HStack, Text, Icon } from '@chakra-ui/react';
+import { MdHome } from 'react-icons/md';
 import { ActiveReader, ReaderManagerArguments } from '../types';
 import useColorModeValue from '../ui/hooks/useColorModeValue';
-import { toggleFullScreen } from '../utils/toggleFullScreen';
 
 import SettingsCard from './SettingsButton';
 import Button from './Button';
 import TableOfContent from './TableOfContent';
 import { HEADER_HEIGHT } from './constants';
+import { MdOutlineFullscreenExit, MdOutlineFullscreen } from 'react-icons/md';
+import useFullscreen from './hooks/useFullScreen';
 
 const DefaultHeaderLeft = (): React.ReactElement => {
   const linkColor = useColorModeValue('gray.700', 'gray.100', 'gray.700');
@@ -28,6 +29,7 @@ const DefaultHeaderLeft = (): React.ReactElement => {
         textDecoration: 'none',
       }}
     >
+      <Icon as={MdHome} w={6} h={6} />
       <Text variant="headerNav">Back to Homepage</Text>
     </Link>
   );
@@ -36,6 +38,7 @@ const DefaultHeaderLeft = (): React.ReactElement => {
 export default function Header(
   props: ActiveReader & ReaderManagerArguments
 ): React.ReactElement {
+  const [isFullscreen, toggleFullScreen] = useFullscreen();
   const { headerLeft, state, navigator, manifest } = props;
   const mainBgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
 
@@ -64,7 +67,11 @@ export default function Header(
         />
         <SettingsCard {...props} />
         <Button border="none" onClick={toggleFullScreen}>
-          <Icon decorative name={IconNames.search} modifiers={['small']} />
+          <Icon
+            as={isFullscreen ? MdOutlineFullscreenExit : MdOutlineFullscreen}
+            w={6}
+            h={6}
+          />
           <Text variant="headerNav">Toggle Fullscreen</Text>
         </Button>
       </HStack>

--- a/src/ui/PdfSettings.tsx
+++ b/src/ui/PdfSettings.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { ButtonGroup, Circle } from '@chakra-ui/react';
-import { Icon, IconNames } from '@nypl/design-system-react-components';
+import { ButtonGroup, Icon } from '@chakra-ui/react';
 import { PdfNavigator, PdfReaderState } from '../types';
 import Button from './Button';
 import ToggleButton from './ToggleButton';
 import ToggleGroup from './ToggleGroup';
+import { MdOutlineZoomIn, MdOutlineZoomOut } from 'react-icons/md';
 
 type PdfSettingsProps = {
   navigator: PdfNavigator;
@@ -28,15 +28,7 @@ export default function PdfSettings(
           variant="toggle"
         >
           Zoom Out
-          <Circle
-            border="1px solid"
-            p={1}
-            ml={1}
-            size="17px"
-            alignItems="baseline"
-          >
-            <Icon decorative name={IconNames.minus} modifiers={['small']} />
-          </Circle>
+          <Icon as={MdOutlineZoomOut} w={7} h={7} pl={1} />
         </Button>
         <Button
           flexGrow={1}
@@ -45,15 +37,7 @@ export default function PdfSettings(
           variant="toggle"
         >
           Zoom In
-          <Circle
-            border="1px solid"
-            p={1}
-            ml={1}
-            size="17px"
-            alignItems="baseline"
-          >
-            <Icon decorative name={IconNames.plus} modifiers={['small']} />
-          </Circle>
+          <Icon as={MdOutlineZoomIn} w={7} h={7} pl={1} />
         </Button>
       </ButtonGroup>
       <ToggleGroup

--- a/src/ui/SettingsButton.tsx
+++ b/src/ui/SettingsButton.tsx
@@ -5,9 +5,10 @@ import {
   PopoverContent,
   PopoverBody,
   Text,
+  Icon,
 } from '@chakra-ui/react';
 import { PDFActiveReader, HTMLActiveReader } from '../types';
-import { Icon, IconNames } from '@nypl/design-system-react-components';
+import { MdOutlineSettings, MdOutlineCancel } from 'react-icons/md';
 
 import Button from './Button';
 import useColorModeValue from './hooks/useColorModeValue';
@@ -22,7 +23,7 @@ export default function SettingsCard(
   props: SettingsCardProps
 ): React.ReactElement {
   const [isOpen, setIsOpen] = React.useState(false);
-  const open = () => setIsOpen(!isOpen);
+  const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
 
   const paginationValue = props.state?.isScrolling ? 'scrolling' : 'paginated';
@@ -33,12 +34,17 @@ export default function SettingsCard(
       <Popover
         placement="bottom"
         isOpen={isOpen}
+        onOpen={open}
         onClose={close}
         autoFocus={true}
       >
         <PopoverTrigger>
           <Button onClick={open} border="none">
-            <Icon decorative name={IconNames.plus} modifiers={['small']} />{' '}
+            <Icon
+              as={isOpen ? MdOutlineCancel : MdOutlineSettings}
+              w={6}
+              h={6}
+            />
             <Text variant="headerNav">Settings</Text>
           </Button>
         </PopoverTrigger>

--- a/src/ui/TableOfContent.tsx
+++ b/src/ui/TableOfContent.tsx
@@ -7,8 +7,9 @@ import {
   MenuList,
   Portal,
   Text,
+  Icon,
 } from '@chakra-ui/react';
-import { Icon, IconNames } from '@nypl/design-system-react-components';
+import { MdOutlineToc, MdOutlineCancel } from 'react-icons/md';
 import { Navigator, ReaderState, WebpubManifest } from '../types';
 import Button from './Button';
 import useColorModeValue from './hooks/useColorModeValue';
@@ -50,7 +51,7 @@ export default function TableOfContent({
       onClose={() => setIsOpen(false)} // To account for "close by lose focus"
     >
       <MenuButton as={Button} border="none">
-        <Icon decorative name={IconNames.download} modifiers={['small']} />
+        <Icon as={isOpen ? MdOutlineCancel : MdOutlineToc} w={6} h={6} />
         <Text variant="headerNav">Table of Contents</Text>
       </MenuButton>
       {isOpen && manifest?.toc && (

--- a/src/ui/ToggleButton.tsx
+++ b/src/ui/ToggleButton.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import {
   Box as ChakraBox,
-  Circle,
   ThemeProvider,
   useRadio,
   useTheme,
+  Icon,
 } from '@chakra-ui/react';
-import { Icon, IconNames } from '@nypl/design-system-react-components';
 
 import Button from './Button';
 import { getTheme } from './theme';
 import { ColorMode } from '../types';
+import { MdOutlineCheckCircle } from 'react-icons/md';
 
 export interface ToggleButtonProps
   extends React.ComponentPropsWithoutRef<typeof ChakraBox> {
@@ -37,19 +37,17 @@ function ToggleButton(
         <Button as="div" {...checkbox} variant="toggle" {...rest} flexGrow={1}>
           {children}
           {isChecked && (
-            <Circle
+            <Icon
+              as={MdOutlineCheckCircle}
               position="absolute"
               verticalAlign="middle"
               right={2}
               top="50%"
               transform="translateY(-50%)"
-              borderColor="white"
-              border="1px solid"
-              size="15px"
               alignItems="baseline"
-            >
-              <Icon decorative name={IconNames.check} modifiers={['small']} />
-            </Circle>
+              w={5}
+              h={5}
+            />
           )}
         </Button>
       </ChakraBox>

--- a/src/ui/hooks/useFullScreen.ts
+++ b/src/ui/hooks/useFullScreen.ts
@@ -1,3 +1,20 @@
+import { useCallback, useState } from 'react';
+
+export default function useFullscreen(): [boolean, () => void] {
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+
+  const updateFullScreenStatus = useCallback(() => {
+    setIsFullscreen(!!isOnFullscreen());
+  }, []);
+
+  document.addEventListener('fullscreenchange', updateFullScreenStatus);
+  document.addEventListener('webkitfullscreenchange', updateFullScreenStatus);
+  document.addEventListener('mozfullscreenchange', updateFullScreenStatus);
+  document.addEventListener('MSFullscreenChange', updateFullScreenStatus);
+
+  return [isFullscreen, toggleFullScreen];
+}
+
 // Methods for Firefox / Safari / Edge
 // We have to cast these types so typescript doesn't complain
 interface FullSpecDocument extends Document {
@@ -47,23 +64,25 @@ const exitFullScreen = () => {
     doc.mozCancelFullScreen ||
     doc.webkitExitFullscreen ||
     doc.msExitFullscreen;
-
   if (typeof exitFunc === 'function') {
     exitFunc.call(doc);
   }
 };
 
-/**
- * Toggles fullscreen mode on the <html> element.
- */
-export function toggleFullScreen() {
-  const isFullscreen =
+export const isOnFullscreen = (() => {
+  const doc = document as FullSpecDocument;
+  return () =>
     doc.fullscreenElement ||
     doc.mozFullScreenElement ||
     doc.webkitFullscreenElement ||
     doc.msFullscreenElement;
+})();
 
-  if (isFullscreen) {
+/**
+ * Toggles fullscreen mode on the <html> element.
+ */
+export function toggleFullScreen(): void {
+  if (isOnFullscreen()) {
     exitFullScreen();
   } else {
     enterFullScreen();

--- a/src/ui/manager.tsx
+++ b/src/ui/manager.tsx
@@ -1,10 +1,6 @@
-import { ThemeProvider, Flex } from '@chakra-ui/react';
-import {
-  Icon,
-  IconNames,
-  IconRotationTypes,
-} from '@nypl/design-system-react-components';
+import { ThemeProvider, Flex, Icon } from '@chakra-ui/react';
 import * as React from 'react';
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
 import { ReaderManagerArguments, ReaderReturn } from '../types';
 import Header from './Header';
 import useColorModeValue from './hooks/useColorModeValue';
@@ -36,15 +32,9 @@ const WebReaderContent: React.FC<ReaderReturn & ReaderManagerArguments> = ({
       <PageButton
         onClick={props.navigator?.goBackward}
         left={0}
-        pr={2}
         aria-label="Previous Page"
       >
-        <Icon
-          decorative
-          name={IconNames.arrow}
-          modifiers={['small']}
-          iconRotation={IconRotationTypes.rotate90}
-        />
+        <Icon as={MdKeyboardArrowLeft} w={6} h={6} />
       </PageButton>
       <Flex
         bg={bgColor}
@@ -59,15 +49,9 @@ const WebReaderContent: React.FC<ReaderReturn & ReaderManagerArguments> = ({
       <PageButton
         onClick={props.navigator?.goForward}
         right={0}
-        pl={2}
         aria-label="Next Page"
       >
-        <Icon
-          decorative
-          name={IconNames.arrow}
-          modifiers={['small']}
-          iconRotation={IconRotationTypes.rotate270}
-        />
+        <Icon as={MdKeyboardArrowRight} w={6} h={6} />
       </PageButton>
     </Flex>
   );

--- a/src/ui/theme/components/text.ts
+++ b/src/ui/theme/components/text.ts
@@ -18,6 +18,7 @@ function variantHeaderNav() {
     letterSpacing: 1,
     fontSize: 0,
     display: { sm: 'none', md: 'none', lg: 'inline-block' },
+    verticalAlign: 'middle',
   };
 }
 

--- a/stories/PageButton.stories.tsx
+++ b/stories/PageButton.stories.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import PageButton, { PageButtonProps } from '../src/ui/PageButton';
-import {
-  Icon,
-  IconNames,
-  IconRotationTypes,
-} from '@nypl/design-system-react-components';
-
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
+import { Icon } from '@chakra-ui/react';
 const meta: Meta = {
   title: 'PageButton',
   component: PageButton,
@@ -30,26 +26,10 @@ const Template: Story<PageButtonProps> = (args) => <PageButton {...args} />;
 export const PreviousButton = Template.bind({});
 
 PreviousButton.args = {
-  children: (
-    <Icon
-      decorative
-      name={IconNames.arrow}
-      modifiers={['small']}
-      iconRotation={IconRotationTypes.rotate90}
-    />
-  ),
-  pr: 2,
+  children: <Icon as={MdKeyboardArrowLeft} w={6} h={6} />,
 };
 
 export const NextButton = Template.bind({});
 NextButton.args = {
-  children: (
-    <Icon
-      decorative
-      name={IconNames.arrow}
-      modifiers={['small']}
-      iconRotation={IconRotationTypes.rotate270}
-    />
-  ),
-  pl: 2,
+  children: <Icon as={MdKeyboardArrowRight} w={6} h={6} />,
 };


### PR DESCRIPTION
This PR updates the icons on the page and uses react-icons as the default.

- Removed NYPL-DS icons and use react-icons instead
- Added toggle state to the icons to display open/close icon
- Added `useFullScreen` hooks for fullscreen state update 
- Added Homepage Icon back for mobile responsive.