### PR TITLE
Fix problematic cypress tests

### DIFF
--- a/cypress/integration/html-reader/injectables.ts
+++ b/cypress/integration/html-reader/injectables.ts
@@ -1,27 +1,30 @@
-// import { IFRAME_SELECTOR } from '../../support/constants';
-
-// FIXME: Consistently failing in CI "parent element is null" ticket to resolve: https://jira.nypl.org/browse/SFR-1378
+import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('useHtmlReader configuration settings', () => {
   it('should have no injectables by default', () => {
-    // cy.loadPage('/test/no-injectables');
-    // cy.getIframeHead(IFRAME_SELECTOR).find('link').should('not.exist');
-    // cy.getIframeHead(IFRAME_SELECTOR).contains('title', 'Cover');
+    cy.loadPage('/test/no-injectables');
+    cy.getIframeHead(IFRAME_SELECTOR)
+      .find('link[href$="/fonts/opensyslexic/opendyslexic.css"]')
+      .should('not.exist');
+    cy.getIframeHead(IFRAME_SELECTOR)
+      .find('link[href$="/css/sample.css"]')
+      .should('not.exist');
+    cy.getIframeHead(IFRAME_SELECTOR).contains('title', 'Title Page');
   });
 
   it('should render css injectables when provided', () => {
-    //   cy.loadPage('/test/with-injectables');
-    //   cy.getIframeHead(IFRAME_SELECTOR).contains('title', 'Cover');
-    //   cy.getIframeHead(IFRAME_SELECTOR)
-    //     .find(`link[href$="/fonts/opensyslexic/opendyslexic.css"]`)
-    //     .should('exist');
-    //   cy.getIframeHead(IFRAME_SELECTOR)
-    //     .find(`link[href$="/css/sample.css"]`)
-    //     .should('exist');
-    //   cy.getIframeBody(IFRAME_SELECTOR).should(
-    //     'have.css',
-    //     'color',
-    //     'rgb(0, 0, 255)'
-    //   );
+    cy.loadPage('/test/with-injectables');
+    cy.getIframeHead(IFRAME_SELECTOR).contains('title', 'Title Page');
+    cy.getIframeHead(IFRAME_SELECTOR)
+      .find(`link[href$="/fonts/opensyslexic/opendyslexic.css"]`)
+      .should('exist');
+    cy.getIframeHead(IFRAME_SELECTOR)
+      .find(`link[href$="/css/sample.css"]`)
+      .should('exist');
+    cy.getIframeBody(IFRAME_SELECTOR).should(
+      'have.css',
+      'color',
+      'rgb(0, 0, 255)'
+    );
   });
 });

--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -2,7 +2,7 @@ import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('navigating an EPUB page', () => {
   beforeEach(() => {
-    cy.loadPage('/moby-epub2');
+    cy.loadPage('/streamed-alice-epub');
   });
 
   it('should contain a link to return to the homepage', () => {
@@ -13,50 +13,21 @@ describe('navigating an EPUB page', () => {
     );
   });
 
+  // FIXME: Finish writing this test once https://jira.nypl.org/browse/SFR-1332 is resolved
   it('Should navigate forward and backwards with page buttons', () => {
-    cy.intercept('GET', '/samples/moby-epub2-exploded/OEBPS/**').as('imprint');
-    cy.intercept('GET', '/samples/moby-epub2-exploded/OEBPS/wrap0000.html').as(
-      'cover'
-    );
-
     cy.log('make sure we are on the homepage');
     cy.getIframeBody(IFRAME_SELECTOR)
       .find('img')
-      .should('have.attr', 'alt', 'Cover');
+      .should(
+        'have.attr',
+        'alt',
+        "Alice's Adventures in Wonderland, by Lewis Carroll"
+      );
 
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.log('make sure we are on paginated mode');
     cy.findByText('Paginated').click();
 
     cy.findByRole('button', { name: 'Next Page' }).click();
-
-    // FIXME: Uncomment the following once https://jira.nypl.org/browse/SFR-1332 is resolved
-    //   cy.wait('@imprint', { timeout: 10000 }).then((interception) => {
-    //     assert.isNotNull(
-    //       interception?.response?.body,
-    //       'imprint API call has data'
-    //     );
-    //   });
-
-    //   cy.wait(3000);
-
-    //   cy.log('then we see the imprint page');
-    //   cy.getIframeBody(IFRAME_SELECTOR).contains(
-    //     'div',
-    //     '*** START OF THE PROJECT GUTENBERG EBOOK MOBY-DICK; OR THE WHALE ***'
-    //   );
-
-    //   cy.findByRole('button', { name: 'Previous Page' }).click();
-
-    //   cy.wait('@cover', { timeout: 10000 }).then((interception) => {
-    //     assert.isNotNull(interception?.response?.body, 'cover API call has data');
-    //   });
-
-    //   cy.wait(3000);
-
-    //   cy.log('make sure we are back on the homepage');
-    //   cy.getIframeBody(IFRAME_SELECTOR)
-    //     .find('img')
-    //     .should('have.attr', 'alt', 'Cover');
   });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -2,7 +2,7 @@ import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('render page content', () => {
   it('Renders content on the epub2 based webpub page', () => {
-    cy.loadPage('/moby-epub2');
+    cy.loadPage('/streamed-alice-epub');
     cy.log('check that all the essential buttons are on the page');
     cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
     cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
@@ -13,6 +13,10 @@ describe('render page content', () => {
     cy.log('page one contains an image');
     cy.getIframeBody(IFRAME_SELECTOR)
       .find('img')
-      .should('have.attr', 'alt', 'Cover');
+      .should(
+        'have.attr',
+        'alt',
+        "Alice's Adventures in Wonderland, by Lewis Carroll"
+      );
   });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -2,17 +2,17 @@ import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('render page content', () => {
   it('Renders content on the epub2 based webpub page', () => {
-    // cy.loadPage('/moby-epub2');
-    // cy.log('check that all the essential buttons are on the page');
-    // cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
-    // cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
-    // cy.findByRole('button', { name: 'Settings' }).should('exist');
-    // cy.findByRole('button', { name: 'Toggle Fullscreen' }).should('exist');
-    // cy.findByRole('button', { name: 'Next Page' }).should('exist');
-    // cy.findByRole('button', { name: 'Previous Page' }).should('exist');
-    // cy.log('page one contains an image');
-    // cy.getIframeBody(IFRAME_SELECTOR)
-    //   .find('img')
-    //   .should('have.attr', 'alt', 'Cover');
+    cy.loadPage('/moby-epub2');
+    cy.log('check that all the essential buttons are on the page');
+    cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
+    cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
+    cy.findByRole('button', { name: 'Settings' }).should('exist');
+    cy.findByRole('button', { name: 'Toggle Fullscreen' }).should('exist');
+    cy.findByRole('button', { name: 'Next Page' }).should('exist');
+    cy.findByRole('button', { name: 'Previous Page' }).should('exist');
+    cy.log('page one contains an image');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img')
+      .should('have.attr', 'alt', 'Cover');
   });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -2,19 +2,17 @@ import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('render page content', () => {
   it('Renders content on the epub2 based webpub page', () => {
-    cy.loadPage('/moby-epub2');
-
-    cy.log('check that all the essential buttons are on the page');
-    cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
-    cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
-    cy.findByRole('button', { name: 'Settings' }).should('exist');
-    cy.findByRole('button', { name: 'Toggle Fullscreen' }).should('exist');
-    cy.findByRole('button', { name: 'Next Page' }).should('exist');
-    cy.findByRole('button', { name: 'Previous Page' }).should('exist');
-
-    cy.log('page one contains an image');
-    cy.getIframeBody(IFRAME_SELECTOR)
-      .find('img')
-      .should('have.attr', 'alt', 'Cover');
+    // cy.loadPage('/moby-epub2');
+    // cy.log('check that all the essential buttons are on the page');
+    // cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
+    // cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
+    // cy.findByRole('button', { name: 'Settings' }).should('exist');
+    // cy.findByRole('button', { name: 'Toggle Fullscreen' }).should('exist');
+    // cy.findByRole('button', { name: 'Next Page' }).should('exist');
+    // cy.findByRole('button', { name: 'Previous Page' }).should('exist');
+    // cy.log('page one contains an image');
+    // cy.getIframeBody(IFRAME_SELECTOR)
+    //   .find('img')
+    //   .should('have.attr', 'alt', 'Cover');
   });
 });

--- a/cypress/integration/html-reader/settings.ts
+++ b/cypress/integration/html-reader/settings.ts
@@ -6,11 +6,12 @@ describe('display settings', () => {
   });
 
   it('should have the default settings', () => {
-    // cy.getIframeHtml(IFRAME_SELECTOR)
-    //   .should('have.attr', 'data-viewer-font', 'publisher')
-    //   .should('have.css', '--USER__appearance', 'readium-default-on')
-    //   .should('have.css', '--USER__fontFamily', 'Original')
-    //   .should('have.css', '--USER__scroll', 'readium-scroll-on');
+    cy.get('#reader-loading').should('not.be.visible');
+    cy.getIframeHtml(IFRAME_SELECTOR)
+      .should('have.attr', 'data-viewer-font', 'publisher')
+      .should('have.css', '--USER__appearance', 'readium-default-on')
+      .should('have.css', '--USER__fontFamily', 'Original')
+      .should('have.css', '--USER__scroll', 'readium-scroll-on');
   });
 
   it('should update the font family to serif, paginated mode, and on sepia theme', () => {

--- a/cypress/integration/html-reader/settings.ts
+++ b/cypress/integration/html-reader/settings.ts
@@ -6,13 +6,11 @@ describe('display settings', () => {
   });
 
   it('should have the default settings', () => {
-    cy.log('briefly see the loading indicator');
-
-    cy.getIframeHtml(IFRAME_SELECTOR)
-      .should('have.attr', 'data-viewer-font', 'publisher')
-      .should('have.css', '--USER__appearance', 'readium-default-on')
-      .should('have.css', '--USER__fontFamily', 'Original')
-      .should('have.css', '--USER__scroll', 'readium-scroll-on');
+    // cy.getIframeHtml(IFRAME_SELECTOR)
+    //   .should('have.attr', 'data-viewer-font', 'publisher')
+    //   .should('have.css', '--USER__appearance', 'readium-default-on')
+    //   .should('have.css', '--USER__fontFamily', 'Original')
+    //   .should('have.css', '--USER__scroll', 'readium-scroll-on');
   });
 
   it('should update the font family to serif, paginated mode, and on sepia theme', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -43,10 +43,12 @@ Cypress.Commands.add('loadPage', (pageName) => {
       win.sessionStorage.clear(); // clear storage so that we are always on page one
     },
   });
+  cy.get('#reader-loading').should('be.visible');
   cy.wait('@sample', { timeout: 20000 }).then((interception) => {
     assert.isNotNull(interception?.response?.body, 'API call has data');
   });
   cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
+  cy.get('#reader-loading').should('not.be.visible');
   cy.get(IFRAME_SELECTOR)
     .its(`0.contentDocument.documentElement`)
     .should('not.be.empty');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -47,11 +47,7 @@ Cypress.Commands.add('loadPage', (pageName) => {
   cy.wait('@sample', { timeout: 20000 }).then((interception) => {
     assert.isNotNull(interception?.response?.body, 'API call has data');
   });
-  cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
   cy.get('#reader-loading').should('not.be.visible');
-  cy.get(IFRAME_SELECTOR)
-    .its(`0.contentDocument.documentElement`)
-    .should('not.be.empty');
 });
 
 Cypress.Commands.add('getIframeHtml', (selector: string = IFRAME_SELECTOR) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -27,11 +27,18 @@ declare global {
   }
 }
 
+const pagesUsingAliceInWonderlandExample: string[] = [
+  '/streamed-alice-epub',
+  '/test/with-injectables',
+  '/test/no-injectables',
+];
+
 Cypress.Commands.add('loadPage', (pageName) => {
-  const resourceInterceptUrl =
-    pageName === '/streamed-alice-epub'
-      ? 'https://alice.dita.digital/**'
-      : '/samples/**';
+  const resourceInterceptUrl = pagesUsingAliceInWonderlandExample.includes(
+    pageName
+  )
+    ? 'https://alice.dita.digital/**'
+    : '/samples/**';
   cy.intercept(resourceInterceptUrl, { middleware: true }, (req) => {
     req.on('before:response', (res) => {
       // force all API responses to not be cached

--- a/example/Tests.tsx
+++ b/example/Tests.tsx
@@ -24,12 +24,12 @@ export default function Tests(): JSX.Element {
       </Route>
       <Route path={`${path}/no-injectables`}>
         <WebReader
-          webpubManifestUrl={`${origin}/samples/moby-epub2-exploded/manifest.json`}
+          webpubManifestUrl={'https://alice.dita.digital/manifest.json'}
         />
       </Route>
       <Route path={`${path}/with-injectables`}>
         <WebReader
-          webpubManifestUrl={`${origin}/samples/moby-epub2-exploded/manifest.json`}
+          webpubManifestUrl={'https://alice.dita.digital/manifest.json'}
           injectables={[
             {
               type: 'style',


### PR DESCRIPTION
**Changes in this PR:**

Switching Cypress tests to only use the `/sreamed-alice-epub` example. The one common denominator with these tests having issues was the `/moby-epub2` resource. With that resource, these were the errors I was seeing in CI:

`TypeError: Cannot read property 'scrollingElement' of null` ⬅️ I think this was coming from R2D2BC

`CypressError: Timed out retrying after 4000ms: cy.should() failed because this element is detached from the DOM.` ⬅️ This is a [known issue](https://github.com/cypress-io/cypress/issues/7306) with Cypress. I watched this [video](https://glebbahmutov.com/blog/detached/) about the best ways to mitigate running into this error, and as far as I can tell the tests as they're currently written are using the best practices he mentions. If we see this one again, let me know and we should pair on it together. Last resort is to add arbitrary `wait()` commands 😬 