### PR TITLE
Define a  default dimension object for the useMeasure hooks instead of null

### DIFF
--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -244,9 +244,7 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
 
   //TODO: Somehow, this window size updates when height
   React.useEffect(() => {
-    if (containerSize) {
-      resizePage(state.pdfWidth, state.pdfHeight, containerSize);
-    }
+    resizePage(state.pdfWidth, state.pdfHeight, containerSize);
   }, [containerSize, state.pdfWidth, state.pdfHeight, resizePage]);
 
   // prev and next page functions
@@ -393,8 +391,10 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
   }
 
   function onRenderSuccess(page: PageProps) {
-    if (!page.height || !page.width || !containerSize)
-      throw new Error('Error rendering page from Reader');
+    if (!page.height || !page.width)
+      throw new Error(
+        'Error rendering page from Reader, please refresh your page.'
+      );
     if (
       Math.round(page.height) !== state.pdfHeight ||
       Math.round(page.width) !== state.pdfWidth
@@ -431,7 +431,7 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
                 Array.from(new Array(state.numPages), (_, index) => (
                   <ChakraPage
                     key={`page_${index + 1}`}
-                    width={containerSize?.width}
+                    width={containerSize.width}
                     scale={state.scale}
                     pageNumber={index + 1}
                   />

--- a/src/PdfReader/useMeasure.tsx
+++ b/src/PdfReader/useMeasure.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 declare const window: Window &
   typeof globalThis & {
-    ResizeObserver: any;
+    ResizeObserver: ResizeObserver;
   };
 export type Dimensions = Pick<
   DOMRectReadOnly,
@@ -11,8 +11,19 @@ export type Dimensions = Pick<
 export type UseMeasureRef<E extends Element = Element> = (element: E) => void;
 export type UseMeasureResult<E extends Element = Element> = [
   UseMeasureRef<E> | null,
-  Dimensions | null
+  Dimensions
 ];
+
+const DEFAULT_DIMENSION = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+};
 
 export default function useMeasure<
   E extends Element = Element
@@ -20,21 +31,21 @@ export default function useMeasure<
   // this is a little trick to get a reference to an HTML element. Using useRef wouldn't
   // work because we actually need rerenders when it changes, to update the useLayoutEffect
   const [element, ref] = React.useState<E | null>(null);
-  const [rect, setRect] = React.useState<Dimensions | null>(null);
+  const [rect, setRect] = React.useState<Dimensions>(DEFAULT_DIMENSION);
   const observer = React.useMemo(
     () =>
       new window.ResizeObserver(
         (
           entries: {
             contentRect: {
-              x: any;
-              y: any;
-              width: any;
-              height: any;
-              top: any;
-              left: any;
-              bottom: any;
-              right: any;
+              x: number;
+              y: number;
+              width: number;
+              height: number;
+              top: number;
+              left: number;
+              bottom: number;
+              right: number;
             };
           }[]
         ) => {


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/SFR-1387)

There's a bug on the PDF page where when the PDF is still loading the content, and immediately tab to a different page, the PDF would fail and return an error.

The logic failed from the `containerSize` variable where it was defaulted to be null, however, adding a default value to the `containerSize` seems to fix the issue. The pdf hook re-renders itself whenever the content updates, we always get the latest container dimensions. 

@kristojorg I'd like your input on this and see if this makes sense to do it this way.