### PR TITLE
Add css height to the HtmlReaderContent

### DIFF
--- a/src/HtmlReader/HtmlReaderContent.tsx
+++ b/src/HtmlReader/HtmlReaderContent.tsx
@@ -4,14 +4,22 @@ const HtmlReaderContent: React.FC<{
   height: string;
   isScrolling: boolean;
   growsWhenScrolling: boolean;
-}> = ({ height }) => {
+}> = ({ height, isScrolling, growsWhenScrolling }) => {
+  const shouldGrow = isScrolling && growsWhenScrolling;
   return (
     <div id="D2Reader-Container">
       <main
         tabIndex={-1}
         id="iframe-wrapper"
         style={{
-          height: height,
+          /**
+           * This determines the height of the iframe.
+           *
+           * If we remove this, then in scrolling mode it simply grows to fit
+           * content. In paginated mode, however, we must have this set because
+           * we have to decide how big the content should be.
+           */
+          height: shouldGrow ? 'initial' : height,
           /**
            * We always want the height to be at least the defined height
            */


### PR DESCRIPTION
This PR adds back the CSS that was removed from the previous PR by me but it should be there for the CSS growing height page to work.