### PR TITLE
Add missing-toc manifest and test

### DIFF
--- a/cypress/integration/html-reader/missing-toc.ts
+++ b/cypress/integration/html-reader/missing-toc.ts
@@ -1,0 +1,18 @@
+import { IFRAME_SELECTOR } from '../../support/constants';
+
+describe('missing-toc', () => {
+  it('Shows mssing TOC message', () => {
+    cy.visit('/test/missing-toc');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('h1')
+      .should('include.text', 'missing Table of Contents');
+
+    cy.log('open TOC menu');
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+
+    cy.findByRole('menu').should(
+      'include.text',
+      'This publication does not have a Table of Contents'
+    );
+  });
+});

--- a/example/Tests.tsx
+++ b/example/Tests.tsx
@@ -61,6 +61,14 @@ export default function Tests(): JSX.Element {
           ]}
         />
       </Route>
+      <Route path={`${path}/missing-toc`}>
+        <WebReader
+          webpubManifestUrl={`${origin}/samples/test/missing-toc.json`}
+          getContent={async (_) => {
+            return `<h1>This manifest is missing Table of Contents</h1>`;
+          }}
+        />
+      </Route>
       <Route path={`${path}/*`}>
         <h1>404</h1>
         <p>Page not found.</p>

--- a/example/static/samples/test/missing-toc.json
+++ b/example/static/samples/test/missing-toc.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://readium.org/webpub-manifest/context.jsonld",
+  "metadata": {
+    "title": "Moby-Dick",
+    "language": "en-US",
+    "author": "Herman Melville"
+  },
+  "resources": [],
+  "readingOrder": [
+    {
+      "href": "OPS/copyright.xhtml",
+      "type": "application/xhtml+xml",
+      "id": "copyright"
+    }
+  ],
+  "toc": [],
+  "links": []
+}


### PR DESCRIPTION
This PR adds missing-toc.json manifest in the sample folder for QA testing. i.e /test/missing-toc