### PR TITLE
Upgrade r2d2bc

### DIFF
--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -8,9 +8,6 @@ describe('navigating an EPUB page using internal link', () => {
     });
 
     cy.loadPage('/moby-epub2');
-
-    // Use a consistent viewport
-    cy.viewport(1024, 768);
   });
 
   it('navigates user using the internal TOC link on the page', () => {
@@ -20,6 +17,8 @@ describe('navigating an EPUB page using internal link', () => {
     cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
 
     cy.wait(3000);
+
+    cy.findByRole('button', { name: 'Next Page' }).click();
 
     cy.log('Go to ETYMOLOGY');
     cy.getIframeBody(IFRAME_SELECTOR)

--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -2,6 +2,11 @@ import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('navigating an EPUB page using internal link', () => {
   beforeEach(() => {
+    // FIXME: Ignore random reader bug for now, remove this after [OE-300]
+    cy.on('uncaught:exception', (err, runnable) => {
+      return false;
+    });
+
     cy.loadPage('/moby-epub2');
 
     // Use a consistent viewport

--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -1,0 +1,29 @@
+import { IFRAME_SELECTOR } from '../../support/constants';
+
+describe('navigating an EPUB page using internal link', () => {
+  beforeEach(() => {
+    cy.loadPage('/moby-epub2');
+
+    // Use a consistent viewport
+    cy.viewport(1024, 768);
+  });
+
+  it('navigates user using the internal TOC link on the page', () => {
+    cy.log('Go to a page with TOC');
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
+
+    cy.wait(3000);
+
+    cy.log('Go to ETYMOLOGY');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('.toc a', { timeout: 3000 })
+      .contains(/^ETYMOLOGY\.$/)
+      .click();
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('h4', { timeout: 3000 })
+      .contains('Original Transcriber’s Notes:');
+  });
+});

--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -31,29 +31,3 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
   });
 });
-
-describe('navigating an EPUB page using internal link', () => {
-  beforeEach(() => {
-    cy.loadPage('/moby-epub2');
-  });
-
-  it('navigates user using the internal TOC link on the page', () => {
-    cy.log('Use scrolling');
-    cy.findByRole('button', { name: 'Settings' }).click();
-    cy.findByText('Scrolling').click();
-
-    cy.log('Go to a page with TOC');
-
-    cy.findByRole('button', { name: 'Table of Contents' }).click();
-    cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
-
-    cy.log('Go to chapter 2');
-    cy.getIframeBody(IFRAME_SELECTOR)
-      .findByText(/The Carpet-Bag/, { timeout: 3000 })
-      .click();
-
-    cy.getIframeBody(IFRAME_SELECTOR)
-      .get('h2', { timeout: 3000 })
-      .should('contain', /CHAPTER 2. The Carpet-Bag./);
-  });
-});

--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -31,3 +31,29 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
   });
 });
+
+describe('navigating an EPUB page using internal link', () => {
+  beforeEach(() => {
+    cy.loadPage('/moby-epub2');
+  });
+
+  it('navigates user using the internal TOC link on the page', () => {
+    cy.log('Use scrolling');
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.log('Go to a page with TOC');
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
+
+    cy.log('Go to chapter 2');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .findByText(/The Carpet-Bag/, { timeout: 3000 })
+      .click();
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .get('h2', { timeout: 3000 })
+      .should('contain', /CHAPTER 2. The Carpet-Bag./);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^1.6.9",
-        "@d-i-t-a/reader": "^2.0.0-beta.4",
+        "@d-i-t-a/reader": "^2.0.0-beta.5",
         "@emotion/react": "^11.4.0",
         "@emotion/styled": "^11.3.0",
         "comlink": "^4.3.1",
@@ -2784,14 +2784,14 @@
       }
     },
     "node_modules/@d-i-t-a/reader": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.4.tgz",
-      "integrity": "sha512-ojRjh4YTZIIP0uMh46K9V0YGLNZrtJ+pZM2a0GDPT5TeXt8ew/7MbutMoY9LJhX8wPIkytBGemGI4BbzUXk4HA==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.5.tgz",
+      "integrity": "sha512-k3OAxsMYmHOxIjBhzCxfmlXEUjKNKRy9EGl7Ko50IPYGlhtB5s2yWoVisVqoVXm5hG7qt62ewDTJ67wRbv9NaA==",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",
         "cssesc": "^3.0.0",
         "detect-browser": "^5.2.0",
-        "devtools-detector": "^2.0.3",
+        "devtools-detector": "^2.0.6",
         "jscrypto": "0.0.1",
         "lodash.clonedeep": "^4.5.0",
         "mark.js": "^8.11.1",
@@ -13738,6 +13738,7 @@
     },
     "node_modules/compare-versions": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "node_modules/component-emitter": {
@@ -15115,8 +15116,9 @@
       "dev": true
     },
     "node_modules/devtools-detector": {
-      "version": "2.0.4",
-      "integrity": "sha512-xWVFy7xrau5Oq6cu8sZh3Zsj5OrYjBdbLqqC2RWUYkdvxNvWmG6yyw+0A5/oaalVSUpfhn5EpL4OUyWrS7RSqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.6.tgz",
+      "integrity": "sha512-O90rhU1MB2Vd/Yq22htRDfELPTOlRr+wemHLkXINlNRSzVn8dk7nnc2dPwLMyqac9ZC3d3vexLYWuwvx7wYIuQ==",
       "dependencies": {
         "compare-versions": "^3.6.0"
       }
@@ -37504,14 +37506,14 @@
       }
     },
     "@d-i-t-a/reader": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.4.tgz",
-      "integrity": "sha512-ojRjh4YTZIIP0uMh46K9V0YGLNZrtJ+pZM2a0GDPT5TeXt8ew/7MbutMoY9LJhX8wPIkytBGemGI4BbzUXk4HA==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.5.tgz",
+      "integrity": "sha512-k3OAxsMYmHOxIjBhzCxfmlXEUjKNKRy9EGl7Ko50IPYGlhtB5s2yWoVisVqoVXm5hG7qt62ewDTJ67wRbv9NaA==",
       "requires": {
         "browserslist-useragent": "^3.0.3",
         "cssesc": "^3.0.0",
         "detect-browser": "^5.2.0",
-        "devtools-detector": "^2.0.3",
+        "devtools-detector": "^2.0.6",
         "jscrypto": "0.0.1",
         "lodash.clonedeep": "^4.5.0",
         "mark.js": "^8.11.1",
@@ -45618,6 +45620,7 @@
     },
     "compare-versions": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "component-emitter": {
@@ -46723,8 +46726,9 @@
       }
     },
     "devtools-detector": {
-      "version": "2.0.4",
-      "integrity": "sha512-xWVFy7xrau5Oq6cu8sZh3Zsj5OrYjBdbLqqC2RWUYkdvxNvWmG6yyw+0A5/oaalVSUpfhn5EpL4OUyWrS7RSqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.6.tgz",
+      "integrity": "sha512-O90rhU1MB2Vd/Yq22htRDfELPTOlRr+wemHLkXINlNRSzVn8dk7nnc2dPwLMyqac9ZC3d3vexLYWuwvx7wYIuQ==",
       "requires": {
         "compare-versions": "^3.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^1.6.9",
-        "@d-i-t-a/reader": "^2.0.0-beta.5",
+        "@d-i-t-a/reader": "^2.0.0-beta.6",
         "@emotion/react": "^11.4.0",
         "@emotion/styled": "^11.3.0",
         "comlink": "^4.3.1",
@@ -2784,9 +2784,9 @@
       }
     },
     "node_modules/@d-i-t-a/reader": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.5.tgz",
-      "integrity": "sha512-k3OAxsMYmHOxIjBhzCxfmlXEUjKNKRy9EGl7Ko50IPYGlhtB5s2yWoVisVqoVXm5hG7qt62ewDTJ67wRbv9NaA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.6.tgz",
+      "integrity": "sha512-Xnk/CwFM5Mw/sjImx4M4uwnrHKKAvuVFStz9gpm+iVZk2BOzLiq8Ro/70tlM0ArRI56tw8L5rxTyd3MExQXo6g==",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",
         "cssesc": "^3.0.0",
@@ -4740,19 +4740,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@nypl-simplified-packages/axisnow-access-control-web": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@nypl-simplified-packages/axisnow-access-control-web/1.4.0/f1d04d5bc0d78982016c6587d80f0153076a1ec68041f62f58318fdbc09b28ec",
-      "integrity": "sha512-BeOoThQAoI4PDgG6empfiAt4cljN0c70MQPtNoBR2Qz/5+PX7OgCN9Na+RKFDeafiGheyuXFQPcc6kh5oHqrZQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.1.7",
-        "@types/pako": "^1.0.1",
-        "node-fetch": "^2.6.1",
-        "pako": "^1.0.11"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -7175,43 +7162,6 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.0.0-alpha.3.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.0.38",
-      "integrity": "sha512-zZ64UpCTm9me15nuCpPgJghSdbEm8atcDQPCyK+bKXjZAQ1735NCZXCSCfbckbQ4MH36Rm9403n/qMq77LFDzQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/asn1js": "^2.0.2",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.1.7",
-      "integrity": "sha512-aCNLYdHZkvGH+T8/YBOY33jrVGVuLIa3bpizeHXqwN+P4ZtixhA+kxEEWM1amZwUY2nY/iuj+5jdZn/zB7EPPQ==",
-      "optional": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.0.32",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.1.6",
-        "tslib": "^2.2.0",
-        "webcrypto-core": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -10294,11 +10244,6 @@
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
-    "node_modules/@types/asn1js": {
-      "version": "2.0.2",
-      "integrity": "sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA==",
-      "optional": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
       "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
@@ -10572,11 +10517,6 @@
       "version": "1.12.1",
       "integrity": "sha512-V25YHbSoKQN35UasHf0EKD9U2vcmexRSp78qa8UglxFH8H3D+adEa9zGZwrqpH4TdvqeMrgMqVqsLB4woAryrQ==",
       "dev": true
-    },
-    "node_modules/@types/pako": {
-      "version": "1.0.2",
-      "integrity": "sha512-8UJl2MjkqqS6ncpLZqRZ5LmGiFBkbYxocD4e4jmBqGvfRG1RS23gKsBQbdtV9O9GvRyjFTiRHRByjSlKCLlmZw==",
-      "optional": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -11708,17 +11648,6 @@
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.0",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/asn1js": {
-      "version": "2.1.1",
-      "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-      "optional": true,
-      "dependencies": {
-        "pvutils": "latest"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/assert": {
       "version": "2.0.0",
@@ -28237,22 +28166,6 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.2.0",
-      "integrity": "sha512-IDefMJEQl7HX0FP2hIKJFnAR11klP1js2ixCrOaMhe3kXFK6RQ2ABUCuwWaaD4ib0hSbh2fGTICvWJJhDfNecA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.0.17",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.10.1",
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
@@ -34775,18 +34688,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/webcrypto-core": {
-      "version": "1.2.1",
-      "integrity": "sha512-5+h1/e/A4eegCRTg+oQ9ehTJRTMwFhZazJ2RH1FP0VC3q1/0xl7x6SzzTwPxd/VTGc7kjuSEJGnfNgoLe5jNRQ==",
-      "optional": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.0.38",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
@@ -37506,9 +37407,9 @@
       }
     },
     "@d-i-t-a/reader": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.5.tgz",
-      "integrity": "sha512-k3OAxsMYmHOxIjBhzCxfmlXEUjKNKRy9EGl7Ko50IPYGlhtB5s2yWoVisVqoVXm5hG7qt62ewDTJ67wRbv9NaA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@d-i-t-a/reader/-/reader-2.0.0-beta.6.tgz",
+      "integrity": "sha512-Xnk/CwFM5Mw/sjImx4M4uwnrHKKAvuVFStz9gpm+iVZk2BOzLiq8Ro/70tlM0ArRI56tw8L5rxTyd3MExQXo6g==",
       "requires": {
         "browserslist-useragent": "^3.0.3",
         "cssesc": "^3.0.0",
@@ -39011,18 +38912,6 @@
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
-      }
-    },
-    "@nypl-simplified-packages/axisnow-access-control-web": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@nypl-simplified-packages/axisnow-access-control-web/1.4.0/f1d04d5bc0d78982016c6587d80f0153076a1ec68041f62f58318fdbc09b28ec",
-      "integrity": "sha512-BeOoThQAoI4PDgG6empfiAt4cljN0c70MQPtNoBR2Qz/5+PX7OgCN9Na+RKFDeafiGheyuXFQPcc6kh5oHqrZQ==",
-      "optional": true,
-      "requires": {
-        "@peculiar/webcrypto": "^1.1.7",
-        "@types/pako": "^1.0.1",
-        "node-fetch": "^2.6.1",
-        "pako": "^1.0.11"
       }
     },
     "@octokit/auth-token": {
@@ -40699,37 +40588,6 @@
         "@parcel/utils": "2.0.0-rc.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
-      }
-    },
-    "@peculiar/asn1-schema": {
-      "version": "2.0.38",
-      "integrity": "sha512-zZ64UpCTm9me15nuCpPgJghSdbEm8atcDQPCyK+bKXjZAQ1735NCZXCSCfbckbQ4MH36Rm9403n/qMq77LFDzQ==",
-      "optional": true,
-      "requires": {
-        "@types/asn1js": "^2.0.2",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@peculiar/json-schema": {
-      "version": "1.1.12",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@peculiar/webcrypto": {
-      "version": "1.1.7",
-      "integrity": "sha512-aCNLYdHZkvGH+T8/YBOY33jrVGVuLIa3bpizeHXqwN+P4ZtixhA+kxEEWM1amZwUY2nY/iuj+5jdZn/zB7EPPQ==",
-      "optional": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.0.32",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.1.6",
-        "tslib": "^2.2.0",
-        "webcrypto-core": "^1.2.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -42882,11 +42740,6 @@
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
-    "@types/asn1js": {
-      "version": "2.0.2",
-      "integrity": "sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA==",
-      "optional": true
-    },
     "@types/babel__core": {
       "version": "7.1.16",
       "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
@@ -43159,11 +43012,6 @@
       "version": "1.12.1",
       "integrity": "sha512-V25YHbSoKQN35UasHf0EKD9U2vcmexRSp78qa8UglxFH8H3D+adEa9zGZwrqpH4TdvqeMrgMqVqsLB4woAryrQ==",
       "dev": true
-    },
-    "@types/pako": {
-      "version": "1.0.2",
-      "integrity": "sha512-8UJl2MjkqqS6ncpLZqRZ5LmGiFBkbYxocD4e4jmBqGvfRG1RS23gKsBQbdtV9O9GvRyjFTiRHRByjSlKCLlmZw==",
-      "optional": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -44069,14 +43917,6 @@
           "version": "4.12.0",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
-      }
-    },
-    "asn1js": {
-      "version": "2.1.1",
-      "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-      "optional": true,
-      "requires": {
-        "pvutils": "latest"
       }
     },
     "assert": {
@@ -56517,19 +56357,6 @@
         }
       }
     },
-    "pvtsutils": {
-      "version": "1.2.0",
-      "integrity": "sha512-IDefMJEQl7HX0FP2hIKJFnAR11klP1js2ixCrOaMhe3kXFK6RQ2ABUCuwWaaD4ib0hSbh2fGTICvWJJhDfNecA==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.2.0"
-      }
-    },
-    "pvutils": {
-      "version": "1.0.17",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
-      "optional": true
-    },
     "qs": {
       "version": "6.10.1",
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
@@ -61508,18 +61335,6 @@
       "version": "1.1.4",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
-    },
-    "webcrypto-core": {
-      "version": "1.2.1",
-      "integrity": "sha512-5+h1/e/A4eegCRTg+oQ9ehTJRTMwFhZazJ2RH1FP0VC3q1/0xl7x6SzzTwPxd/VTGc7kjuSEJGnfNgoLe5jNRQ==",
-      "optional": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.0.38",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
-        "tslib": "^2.3.1"
-      }
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.9",
-    "@d-i-t-a/reader": "^2.0.0-beta.5",
+    "@d-i-t-a/reader": "^2.0.0-beta.6",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "comlink": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.9",
-    "@d-i-t-a/reader": "^2.0.0-beta.4",
+    "@d-i-t-a/reader": "^2.0.0-beta.5",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "comlink": "^4.3.1",


### PR DESCRIPTION
This upgrade fixes [OE-227](https://jira.nypl.org/browse/OE-227), that, when the user clicks on an internal link, it should navigate the user if it's found in the readeringOrder in the manifest instead of downloading the resource.