### PR TITLE
Release 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/web-reader",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "repository": "https://github.com/NYPL-Simplified/web-reader",
   "homepage": "https://github.com/NYPL-Simplified/web-reader",


### PR DESCRIPTION
This patch includes the following update:

- A message output for books without a TOC. [Link](https://github.com/NYPL-Simplified/web-reader/pull/106)
- Bring back the CSS height setting to the HtmlReaderContent for the height-growing page. [Link](https://github.com/NYPL-Simplified/web-reader/pull/108)
- Upgrade r2d2bc version with the internal-link fix [Link](https://github.com/NYPL-Simplified/web-reader/pull/110)