### PR TITLE
Fix/cypress test

### DIFF
--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -7,7 +7,7 @@ describe('navigating an EPUB page using internal link', () => {
       return false;
     });
 
-    cy.visit('/moby-epub2', {
+    cy.visit('moby-epub2', {
       onBeforeLoad: (win) => {
         win.sessionStorage.clear(); // clear storage so that we are always on page one
       },
@@ -17,11 +17,18 @@ describe('navigating an EPUB page using internal link', () => {
   it('navigates user using the internal TOC link on the page', () => {
     cy.log('Go to a page with TOC');
 
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img', { timeout: 5000 })
+      .should('have.attr', 'alt', 'Cover');
+
+    cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
+
     cy.findByRole('button', { name: 'Table of Contents' }).click();
     cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
 
     cy.wait(3000);
 
+    cy.findByRole('button', { name: 'Next Page' }).should('exist');
     cy.findByRole('button', { name: 'Next Page' }).click();
 
     cy.log('Go to ETYMOLOGY');

--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -7,7 +7,11 @@ describe('navigating an EPUB page using internal link', () => {
       return false;
     });
 
-    cy.loadPage('/moby-epub2');
+    cy.visit('/moby-epub2', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear(); // clear storage so that we are always on page one
+      },
+    });
   });
 
   it('navigates user using the internal TOC link on the page', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/web-reader",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "repository": "https://github.com/NYPL-Simplified/web-reader",
   "homepage": "https://github.com/NYPL-Simplified/web-reader",


### PR DESCRIPTION
This PR updates the internal-link test to use `cy.visit` to load the test page