### PR TITLE
Fix missing parentheses in call to skipWaiting

### DIFF
--- a/src/ServiceWorker/sw.ts
+++ b/src/ServiceWorker/sw.ts
@@ -40,7 +40,7 @@ export default function initWebReaderSW({
       await self.skipWaiting();
       log('INSTALLED');
     }
-    event.waitUntil(installSW);
+    event.waitUntil(installSW());
   });
 
   /**


### PR DESCRIPTION
The intention of the code is to not wait for the pages the current
service worker is controlling to be closed before updating the SW. This
was not happening because an async method was being passed to waitUntil,
rather than actually calling it and thus producing the promise that this
method expects in the SW.

I am unsure how this might be tested (it obviously wasn't previously!), and definitely have no relevant experience with doing so in a robust manner. Please let me know if there is a good way to test this.