### PR TITLE
Add extra cypress tests

### DIFF
--- a/cypress/integration/html-reader/get-content.ts
+++ b/cypress/integration/html-reader/get-content.ts
@@ -1,9 +1,7 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('getContent', () => {
   it('getContent returns HTML', () => {
     cy.visit('/test/get-content');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('p')
       .should('include.text', '/samples/moby-epub2-exploded/OEBPS/');
   });

--- a/cypress/integration/html-reader/injectables.ts
+++ b/cypress/integration/html-reader/injectables.ts
@@ -1,28 +1,20 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('useHtmlReader configuration settings', () => {
   it('should have no injectables by default', () => {
     cy.loadPage('/test/no-injectables');
-    cy.getIframeHead(IFRAME_SELECTOR)
+    cy.getIframeHead()
       .find('link[href$="/fonts/opensyslexic/opendyslexic.css"]')
       .should('not.exist');
-    cy.getIframeHead(IFRAME_SELECTOR)
+    cy.getIframeHead()
       .find('link[href$="/css/sample.css"]')
       .should('not.exist');
   });
 
   it('should render css injectables when provided', () => {
     cy.loadPage('/test/with-injectables');
-    cy.getIframeHead(IFRAME_SELECTOR)
+    cy.getIframeHead()
       .find(`link[href$="/fonts/opensyslexic/opendyslexic.css"]`)
       .should('exist');
-    cy.getIframeHead(IFRAME_SELECTOR)
-      .find(`link[href$="/css/sample.css"]`)
-      .should('exist');
-    cy.getIframeBody(IFRAME_SELECTOR).should(
-      'have.css',
-      'color',
-      'rgb(0, 0, 255)'
-    );
+    cy.getIframeHead().find(`link[href$="/css/sample.css"]`).should('exist');
+    cy.getIframeBody().should('have.css', 'color', 'rgb(0, 0, 255)');
   });
 });

--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -10,7 +10,7 @@ describe('navigating an EPUB page using internal link', () => {
     cy.loadPage('/moby-epub2');
   });
 
-  it('navigates user using the internal TOC link on the page', () => {
+  it('Paginated mode & internal links should navigates users', () => {
     cy.log('Go to a page with TOC');
 
     cy.findByRole('button', { name: 'Table of Contents' }).click();
@@ -29,5 +29,31 @@ describe('navigating an EPUB page using internal link', () => {
     cy.getIframeBody(IFRAME_SELECTOR)
       .find('h4', { timeout: 3000 })
       .contains('Original Transcriber’s Notes:');
+  });
+
+  it('Scrolling mode & internal links should navigates users', () => {
+    cy.log('Go to a page with TOC');
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.findByLabelText('MOBY-DICK; or, THE WHALE.').click();
+
+    cy.wait(3000);
+
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.wait(1000);
+
+    cy.log('Go to Chapter 133');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('.toc a', { timeout: 3000 })
+      .contains(/^CHAPTER 133. The Chase—First Day\.$/)
+      .click();
+
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('h2', { timeout: 3000 })
+      .contains('CHAPTER 133. The Chase—First Day');
   });
 });

--- a/cypress/integration/html-reader/internal-link.ts
+++ b/cypress/integration/html-reader/internal-link.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('navigating an EPUB page using internal link', () => {
   beforeEach(() => {
     // FIXME: Ignore random reader bug for now, remove this after [OE-300]
@@ -21,12 +19,12 @@ describe('navigating an EPUB page using internal link', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
 
     cy.log('Go to ETYMOLOGY');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('.toc a', { timeout: 3000 })
       .contains(/^ETYMOLOGY\.$/)
       .click();
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('h4', { timeout: 3000 })
       .contains('Original Transcriber’s Notes:');
   });
@@ -45,14 +43,14 @@ describe('navigating an EPUB page using internal link', () => {
     cy.wait(1000);
 
     cy.log('Go to Chapter 133');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('.toc a', { timeout: 3000 })
       .contains(/^CHAPTER 133. The Chase—First Day\.$/)
       .click();
 
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('h2', { timeout: 3000 })
       .contains('CHAPTER 133. The Chase—First Day');
   });

--- a/cypress/integration/html-reader/missing-toc.ts
+++ b/cypress/integration/html-reader/missing-toc.ts
@@ -1,4 +1,4 @@
-describe('missing-toc', () => {
+describe('Book without a TOC or empty TOC menulist', () => {
   it('Shows mssing TOC message', () => {
     cy.visit('/test/missing-toc');
     cy.getIframeBody()

--- a/cypress/integration/html-reader/missing-toc.ts
+++ b/cypress/integration/html-reader/missing-toc.ts
@@ -1,9 +1,7 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('missing-toc', () => {
   it('Shows mssing TOC message', () => {
     cy.visit('/test/missing-toc');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('h1')
       .should('include.text', 'missing Table of Contents');
 

--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('navigating an EPUB page', () => {
   beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
@@ -15,7 +13,7 @@ describe('navigating an EPUB page', () => {
 
   it('Paginated mode & page buttons should navigate users forward and backwards', () => {
     cy.log('make sure we are on the homepage');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should(
         'have.attr',
@@ -30,11 +28,11 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('a')
       .first()
       .should('have.attr', 'href', 'https://standardebooks.org');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should('have.attr', 'alt', 'The Standard Ebooks logo');
 
@@ -43,7 +41,7 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Previous Page' }).click();
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should(
         'have.attr',
@@ -59,12 +57,12 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('a')
       .first()
       .should('have.attr', 'href', 'https://standardebooks.org');
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should('have.attr', 'alt', 'The Standard Ebooks logo');
 
@@ -73,7 +71,7 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Previous Page' }).click();
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should(
         'have.attr',
@@ -102,8 +100,6 @@ describe('navigating an EPUB page', () => {
     cy.findByRole('button', { name: 'Next Page' }).click();
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR)
-      .find('h2')
-      .should('contain.text', 'The Pool of Tears');
+    cy.getIframeBody().find('h2').should('contain.text', 'The Pool of Tears');
   });
 });

--- a/cypress/integration/html-reader/navigations.ts
+++ b/cypress/integration/html-reader/navigations.ts
@@ -13,8 +13,7 @@ describe('navigating an EPUB page', () => {
     );
   });
 
-  // FIXME: Finish writing this test once https://jira.nypl.org/browse/SFR-1332 is resolved
-  it('Should navigate forward and backwards with page buttons', () => {
+  it('Paginated mode & page buttons should navigate users forward and backwards', () => {
     cy.log('make sure we are on the homepage');
     cy.getIframeBody(IFRAME_SELECTOR)
       .find('img')
@@ -29,5 +28,82 @@ describe('navigating an EPUB page', () => {
     cy.findByText('Paginated').click();
 
     cy.findByRole('button', { name: 'Next Page' }).click();
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('a')
+      .first()
+      .should('have.attr', 'href', 'https://standardebooks.org');
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img')
+      .should('have.attr', 'alt', 'The Standard Ebooks logo');
+
+    cy.log('return to the homepage');
+
+    cy.findByRole('button', { name: 'Previous Page' }).click();
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img')
+      .should(
+        'have.attr',
+        'alt',
+        "Alice's Adventures in Wonderland, by Lewis Carroll"
+      );
+  });
+
+  it('Scrolling mode & page buttons should navigate users forward and backwards', () => {
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Next Page' }).click();
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('a')
+      .first()
+      .should('have.attr', 'href', 'https://standardebooks.org');
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img')
+      .should('have.attr', 'alt', 'The Standard Ebooks logo');
+
+    cy.log('return to the homepage');
+
+    cy.findByRole('button', { name: 'Previous Page' }).click();
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('img')
+      .should(
+        'have.attr',
+        'alt',
+        "Alice's Adventures in Wonderland, by Lewis Carroll"
+      );
+  });
+
+  it('should load the next chapter if user scrolled to the buttom of the page and pressed the next button', () => {
+    cy.log('scrolling mode');
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+
+    cy.log('open chapter 1');
+    cy.findByRole('menuitem', { name: 'I: Down the Rab­bit-Hole' }).click();
+
+    cy.wait(1000);
+
+    cy.log('scroll to the bottom of the page');
+    cy.window().scrollTo('bottom');
+    cy.wait(1000);
+
+    cy.log('click next button');
+    cy.findByRole('button', { name: 'Next Page' }).click();
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR)
+      .find('h2')
+      .should('contain.text', 'The Pool of Tears');
   });
 });

--- a/cypress/integration/html-reader/page-button.ts
+++ b/cypress/integration/html-reader/page-button.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('PageButton visibility on useHtmlReader', () => {
   beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
@@ -43,7 +41,7 @@ describe('PageButton visibility on useHtmlReader', () => {
 
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+    cy.getIframeBody().find('.copyright-page').should('exist');
 
     cy.wait(1000);
 
@@ -79,7 +77,7 @@ describe('PageButton visibility on useHtmlReader', () => {
 
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+    cy.getIframeBody().find('.copyright-page').should('exist');
 
     cy.wait(1000);
 
@@ -115,7 +113,7 @@ describe('PageButton visibility on useHtmlReader', () => {
 
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+    cy.getIframeBody().find('.copyright-page').should('exist');
 
     cy.wait(1000);
 
@@ -157,7 +155,7 @@ describe('PageButton visibility on useHtmlReader', () => {
 
     cy.wait(1000);
 
-    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+    cy.getIframeBody().find('.copyright-page').should('exist');
 
     cy.wait(1000);
 

--- a/cypress/integration/html-reader/page-button.ts
+++ b/cypress/integration/html-reader/page-button.ts
@@ -5,47 +5,33 @@ describe('PageButton visibility on useHtmlReader', () => {
     cy.loadPage('/streamed-alice-epub');
   });
 
-  it('Should disable previous page button at the start of the book', () => {
+  it('Paginated mode & at the start of the book previous page button should be disabled', () => {
     cy.findByRole('button', { name: 'Next Page' }).should('not.be.disabled');
     cy.findByRole('button', { name: 'Previous Page' }).should('be.disabled');
-
-    cy.log('On Paginated Mode');
 
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Paginated').click();
 
     cy.findByRole('button', { name: 'Next Page' }).should('not.be.disabled');
     cy.findByRole('button', { name: 'Previous Page' }).should('be.disabled');
-
-    //TODO: find a single resource webpub to test the scrolling mode
   });
 
-  it('Should enable previous page button after moving to the next page', () => {
-    cy.findByRole('button', { name: 'Settings' }).click();
-    cy.findByText('Paginated').click();
-
-    cy.findByRole('button', { name: 'Next Page' }).click();
-
+  it('Scrolling mode & at the start of the book previous page button should be disabled', () => {
     cy.findByRole('button', { name: 'Next Page' }).should('not.be.disabled');
-    cy.findByRole('button', { name: 'Previous Page' }).should(
-      'not.be.disabled'
-    );
+    cy.findByRole('button', { name: 'Previous Page' }).should('be.disabled');
 
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Scrolling').click();
 
     cy.findByRole('button', { name: 'Next Page' }).should('not.be.disabled');
-    cy.findByRole('button', { name: 'Previous Page' }).should(
-      'not.be.disabled'
-    );
+    cy.findByRole('button', { name: 'Previous Page' }).should('be.disabled');
   });
 
-  it('Should disable next page button at the end of the book', () => {
+  it('Paginated mode & at the end of the book the next page button should be disabled', () => {
     cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
       'uncopyright'
     );
 
-    // The load time for Scrolling mode is extreamly unpredictable, better to use paginated
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Paginated').click();
 
@@ -77,12 +63,47 @@ describe('PageButton visibility on useHtmlReader', () => {
     );
   });
 
-  it('Should toggle the page buttons when the screen is resized', () => {
+  it('Scrolling mode & at the end of the book the next page button should be disabled', () => {
     cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
       'uncopyright'
     );
 
-    // The load time for Scrolling mode is extreamly unpredictable, better to use paginated
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.log('move to last chapter');
+    cy.findByRole('menuitem', { name: /(.*copy.*right$)/ }).click();
+
+    cy.wait('@uncopyright', { timeout: 10000 });
+
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+
+    cy.wait(1000);
+
+    cy.findByRole('button', { name: 'Next Page' }).should('be.disabled');
+    cy.findByRole('button', { name: 'Previous Page' }).should(
+      'not.be.disabled'
+    );
+
+    cy.log('Press the Previous page button to reveal the next page button');
+    cy.findByRole('button', { name: 'Previous Page' }).click();
+
+    cy.wait(1000);
+
+    cy.findByRole('button', { name: 'Next Page' }).should('not.be.disabled');
+    cy.findByRole('button', { name: 'Previous Page' }).should(
+      'not.be.disabled'
+    );
+  });
+
+  it('Paginated mode & screen resize should toggle the page buttons visibility', () => {
+    cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
+      'uncopyright'
+    );
+
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Paginated').click();
 
@@ -113,6 +134,44 @@ describe('PageButton visibility on useHtmlReader', () => {
 
     cy.log('switch back to default viewport');
     cy.viewport(1000, 600);
+
+    cy.findByRole('button', { name: 'Next Page' }).should('be.disabled');
+    cy.findByRole('button', { name: 'Previous Page' }).should(
+      'not.be.disabled'
+    );
+  });
+
+  it('Scrolling mode & screen resize should toggle the page button visibility', () => {
+    cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
+      'uncopyright'
+    );
+
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.log('move to last chapter');
+    cy.findByRole('menuitem', { name: /(.*copy.*right$)/ }).click();
+
+    cy.wait('@uncopyright', { timeout: 10000 });
+
+    cy.wait(1000);
+
+    cy.getIframeBody(IFRAME_SELECTOR).find('.copyright-page').should('exist');
+
+    cy.wait(1000);
+
+    cy.log('scroll to the bottom of the page');
+    cy.window().scrollTo('bottom');
+    cy.wait(1000);
+
+    cy.findByRole('button', { name: 'Next Page' }).should('be.disabled');
+    cy.findByRole('button', { name: 'Previous Page' }).should(
+      'not.be.disabled'
+    );
+
+    cy.log('Small screen should disable next button');
+    cy.viewport(100, 100);
 
     cy.findByRole('button', { name: 'Next Page' }).should('be.disabled');
     cy.findByRole('button', { name: 'Previous Page' }).should(

--- a/cypress/integration/html-reader/page-button.ts
+++ b/cypress/integration/html-reader/page-button.ts
@@ -97,7 +97,7 @@ describe('PageButton visibility on useHtmlReader', () => {
     );
   });
 
-  it('Paginated mode & screen resize should toggle the page buttons visibility', () => {
+  it('Paginated mode & screen resize should show/hide the page buttons', () => {
     cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
       'uncopyright'
     );
@@ -139,7 +139,7 @@ describe('PageButton visibility on useHtmlReader', () => {
     );
   });
 
-  it('Scrolling mode & screen resize should toggle the page button visibility', () => {
+  it('Scrolling mode & screen resize should show/hide the page buttons', () => {
     cy.intercept('GET', 'https://alice.dita.digital/text/uncopyright.xhtml').as(
       'uncopyright'
     );

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -52,7 +52,7 @@ describe('render page content', () => {
   });
 
   // Scroll to the bottom of the page, but if the screen is resized to be smaller, vertical scroll bar should re-appear to allow user to scroll down
-  it.only('Scrolling mode & resize to smaller screen shows you are not at the end of the chapter', () => {
+  it('Scrolling mode & resize to smaller screen shows you are not at the end of the chapter', () => {
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Scrolling').click();
 
@@ -65,7 +65,10 @@ describe('render page content', () => {
     cy.log('scroll to the bottom of the page');
     cy.window().scrollTo('bottom');
     cy.window().then((win) => {
-      expect(win.innerHeight + win.scrollY).eq(win.document.body.offsetHeight);
+      // https://stackoverflow.com/a/9439807/17573442
+      const scrolledPosition = win.innerHeight + win.scrollY;
+      const elmHeight = win.document.body.offsetHeight;
+      expect(scrolledPosition).eq(elmHeight);
     });
 
     cy.log(
@@ -74,9 +77,9 @@ describe('render page content', () => {
     cy.viewport(500, 500);
 
     cy.window().then((win) => {
-      expect(win.innerHeight + win.scrollY).not.eq(
-        win.document.body.offsetHeight
-      );
+      const scrolledPosition = win.innerHeight + win.scrollY;
+      const elmHeight = win.document.body.offsetHeight;
+      expect(scrolledPosition).not.eq(elmHeight);
     });
   });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -50,4 +50,33 @@ describe('render page content', () => {
     cy.window().its('scrollY').should('eq', 100);
     cy.window().its('scrollX').should('eq', 0);
   });
+
+  // Scroll to the bottom of the page, but if the screen is resized to be smaller, vertical scroll bar should re-appear to allow user to scroll down
+  it.only('Scrolling mode & resize to smaller screen shows you are not at the end of the chapter', () => {
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.log('open chapter 1');
+    cy.findByRole('menuitem', { name: 'I: Down the Rab­bit-Hole' }).click();
+
+    cy.wait(1000);
+
+    cy.log('scroll to the bottom of the page');
+    cy.window().scrollTo('bottom');
+    cy.window().then((win) => {
+      expect(win.innerHeight + win.scrollY).eq(win.document.body.offsetHeight);
+    });
+
+    cy.log(
+      'resize the screen to be smaller so the vertical scroll bar appears'
+    );
+    cy.viewport(500, 500);
+
+    cy.window().then((win) => {
+      expect(win.innerHeight + win.scrollY).not.eq(
+        win.document.body.offsetHeight
+      );
+    });
+  });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -34,7 +34,7 @@ describe('render page content', () => {
     cy.window().its('scrollX').should('eq', 0);
   });
 
-  it('Scrolling mode & horizontal scroll bars should not exist', () => {
+  it('Scrolling mode & horizontal scroll bars should not exist but should be able to scroll vertically', () => {
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Scrolling').click();
 
@@ -44,9 +44,9 @@ describe('render page content', () => {
 
     cy.wait(1000);
 
+    cy.log('scrollable vertically but not horizontally');
     cy.window().scrollTo(100, 100, { ensureScrollable: false });
 
-    cy.log('scrollable vertically but not horizontally');
     cy.window().its('scrollY').should('eq', 100);
     cy.window().its('scrollX').should('eq', 0);
   });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -1,8 +1,11 @@
 import { IFRAME_SELECTOR } from '../../support/constants';
 
 describe('render page content', () => {
-  it('Renders content on the epub2 based webpub page', () => {
+  beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
+  });
+
+  it('Renders content on the epub2 based webpub page', () => {
     cy.log('check that all the essential buttons are on the page');
     cy.findByRole('link', { name: 'Return to Homepage' }).should('exist');
     cy.findByRole('button', { name: 'Table of Contents' }).should('exist');
@@ -20,5 +23,33 @@ describe('render page content', () => {
         'alt',
         "Alice's Adventures in Wonderland, by Lewis Carroll"
       );
+  });
+
+  it('Paginated mode & vertical and horizontal scroll bars should not exist', () => {
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Paginated').click();
+
+    cy.log('attemp to scroll the page');
+    cy.window().scrollTo(100, 100, { ensureScrollable: false });
+
+    cy.window().its('scrollY').should('eq', 0);
+    cy.window().its('scrollX').should('eq', 0);
+  });
+
+  it('Scrolling mode & horizontal scroll bars should not exist', () => {
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+    cy.log('open chapter 1');
+    cy.findByRole('menuitem', { name: 'I: Down the Rab­bit-Hole' }).click();
+
+    cy.wait(1000);
+
+    cy.window().scrollTo(100, 100, { ensureScrollable: false });
+
+    cy.log('scrollable vertically but not horizontally');
+    cy.window().its('scrollY').should('eq', 100);
+    cy.window().its('scrollX').should('eq', 0);
   });
 });

--- a/cypress/integration/html-reader/render-app.ts
+++ b/cypress/integration/html-reader/render-app.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('render page content', () => {
   beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
@@ -16,7 +14,7 @@ describe('render page content', () => {
     cy.findByRole('button', { name: 'Previous Page' }).should('be.disabled');
 
     cy.log('page one contains an image');
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img')
       .should(
         'have.attr',

--- a/cypress/integration/html-reader/settings.ts
+++ b/cypress/integration/html-reader/settings.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('display settings', () => {
   beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
@@ -9,7 +7,7 @@ describe('display settings', () => {
     cy.get('#reader-loading').should('not.be.visible');
     // without this wait we are getting "element is detached from dom" errors
     cy.wait(3000);
-    cy.getIframeHtml(IFRAME_SELECTOR)
+    cy.getIframeHtml()
       .should('have.attr', 'data-viewer-font', 'publisher')
       .should('have.css', '--USER__appearance', 'readium-default-on')
       .should('have.css', '--USER__fontFamily', 'Original')
@@ -24,26 +22,19 @@ describe('display settings', () => {
     cy.findByText('Scrolling').click();
     cy.findByText('Sepia').click();
 
-    cy.getIframeHtml(IFRAME_SELECTOR)
+    cy.getIframeHtml()
       .should('have.attr', 'data-viewer-font', 'serif')
       .should('have.css', '--USER__appearance', 'readium-sepia-on')
       .should('have.css', '--USER__scroll', 'readium-scroll-on');
   });
 
   it('should trigger font size setting', () => {
-    cy.getIframeHtml(IFRAME_SELECTOR).should(
-      'not.have.css',
-      '--USER__fontSize'
-    ); // by default, there's no font size set on the page
+    cy.getIframeHtml().should('not.have.css', '--USER__fontSize'); // by default, there's no font size set on the page
 
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByRole('button', { name: 'Decrease font size' }).click();
 
-    cy.getIframeHtml(IFRAME_SELECTOR).should(
-      'have.css',
-      '--USER__fontSize',
-      '96%'
-    ); // 4% per step?
+    cy.getIframeHtml().should('have.css', '--USER__fontSize', '96%'); // 4% per step?
   });
 
   it('should stay on the same page when switching between reading modes', () => {
@@ -58,7 +49,7 @@ describe('display settings', () => {
 
     cy.wait(1000);
 
-    cy.getIframeHtml(IFRAME_SELECTOR)
+    cy.getIframeHtml()
       .find('h2')
       .contains('I Down the Rab­bit-Hole')
       .should('be.visible');
@@ -67,7 +58,7 @@ describe('display settings', () => {
     cy.findByRole('button', { name: 'Settings' }).click();
     cy.findByText('Scrolling').click();
 
-    cy.getIframeHtml(IFRAME_SELECTOR)
+    cy.getIframeHtml()
       .find('h2')
       .contains('I Down the Rab­bit-Hole')
       .should('be.visible');

--- a/cypress/integration/html-reader/settings.ts
+++ b/cypress/integration/html-reader/settings.ts
@@ -45,4 +45,31 @@ describe('display settings', () => {
       '96%'
     ); // 4% per step?
   });
+
+  it('should stay on the same page when switching between reading modes', () => {
+    cy.log('Make sure we are on paginated mode');
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Paginated').click();
+
+    cy.findByRole('button', { name: 'Table of Contents' }).click();
+
+    cy.log('open chapter 1');
+    cy.findByRole('menuitem', { name: 'I: Down the Rab­bit-Hole' }).click();
+
+    cy.wait(1000);
+
+    cy.getIframeHtml(IFRAME_SELECTOR)
+      .find('h2')
+      .contains('I Down the Rab­bit-Hole')
+      .should('be.visible');
+
+    cy.log('switch to scrolling mode');
+    cy.findByRole('button', { name: 'Settings' }).click();
+    cy.findByText('Scrolling').click();
+
+    cy.getIframeHtml(IFRAME_SELECTOR)
+      .find('h2')
+      .contains('I Down the Rab­bit-Hole')
+      .should('be.visible');
+  });
 });

--- a/cypress/integration/html-reader/toc-navigation.ts
+++ b/cypress/integration/html-reader/toc-navigation.ts
@@ -1,5 +1,3 @@
-import { IFRAME_SELECTOR } from '../../support/constants';
-
 describe('navigating an EPUB page', () => {
   beforeEach(() => {
     cy.loadPage('/streamed-alice-epub');
@@ -10,7 +8,7 @@ describe('navigating an EPUB page', () => {
       'chapterOne'
     );
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img', { timeout: 10000 })
       .should(
         'have.attr',
@@ -38,10 +36,7 @@ describe('navigating an EPUB page', () => {
 
     cy.wait(3000);
 
-    cy.getIframeHead(IFRAME_SELECTOR).contains(
-      'title',
-      'Chapter 1: Down the Rabbit-Hole'
-    );
+    cy.getIframeHead().contains('title', 'Chapter 1: Down the Rabbit-Hole');
   });
 
   it('Scrolling mode & TOC: should update page content after clicking on TOC link', () => {
@@ -49,7 +44,7 @@ describe('navigating an EPUB page', () => {
       'chapterOne'
     );
 
-    cy.getIframeBody(IFRAME_SELECTOR)
+    cy.getIframeBody()
       .find('img', { timeout: 10000 })
       .should(
         'have.attr',
@@ -77,9 +72,6 @@ describe('navigating an EPUB page', () => {
 
     cy.wait(3000);
 
-    cy.getIframeHead(IFRAME_SELECTOR).contains(
-      'title',
-      'Chapter 1: Down the Rabbit-Hole'
-    );
+    cy.getIframeHead().contains('title', 'Chapter 1: Down the Rabbit-Hole');
   });
 });


### PR DESCRIPTION
This PR adds extra cypress tests to the HTML renderer section and also validates other tests, which should cover the following test scenarios

- [x] when you scroll to the bottom of the chapter and press "next", it knows that it's at the end of the chapter and loads the next one
- [x] when you scroll, then resize, it knows you're not yet at the end of the chapter
- [x] Internal links works on both paginated and scrolling mode
- [x] TOC navigates on paginated and scrolling mode
- [x] Height and width problem, make sure there are no extra scrollbars
- [x] All the settings under the settings button
- [x] Next / Previous button response to book state (navigates + hide/show state)