### PR TITLE
Add script injectables support

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,7 +67,7 @@ jobs:
         run: npm i --omit=optional
 
       - name: Run Chrome
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4.0.1
         env:
           CYPRESS_BASE_URL: ${{ github.event.deployment_status.target_url }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,9 +77,10 @@ jobs:
         with:
           install: false
           browser: chrome
+          headed: true
           record: true
           parallel: true
-          group: 'UI - Chrome'
+          group: "UI - Chrome"
 
       - name: Upload failure screenshots
         uses: actions/upload-artifact@v2

--- a/cypress/integration/html-reader/injectables.ts
+++ b/cypress/integration/html-reader/injectables.ts
@@ -9,6 +9,15 @@ describe('useHtmlReader configuration settings', () => {
       .should('not.exist');
   });
 
+  it('should render injectables script when provided', () => {
+    cy.log('Reflowable Book with both fixed and reflowable CSS injected');
+    cy.loadPage('/html/test/with-script-injectable');
+
+    cy.getIframeHead()
+      .find(`script[src$="/js/sample.js"]`, { timeout: 50000 })
+      .should('exist');
+  });
+
   it('should render reflowable injectables CSS when provided for reflowable books', () => {
     cy.log('Reflowable Book with both fixed and reflowable CSS injected');
     cy.loadPage('/html/test/with-reflowable-layout');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,6 +15,7 @@ declare global {
           | '/html/axisnow-decrypted'
           | '/html/test/no-injectables'
           | '/html/test/with-reflowable-layout'
+          | '/html/test/with-script-injectable'
           | '/html/test/with-fixed-layout'
           | '/html/test/get-content'
           | '/html/streamed-alice-epub'
@@ -36,6 +37,7 @@ declare global {
 const pagesUsingAliceInWonderlandExample: string[] = [
   '/html/streamed-alice-epub',
   '/html/test/with-reflowable-layout',
+  '/html/test/with-script-injectable',
   '/html/test/no-injectables',
 ];
 

--- a/example/Tests.tsx
+++ b/example/Tests.tsx
@@ -26,6 +26,18 @@ export default function Tests(): JSX.Element {
           webpubManifestUrl={'https://alice.dita.digital/manifest.json'}
         />
       </Route>
+      <Route path={`${path}/with-script-injectable`}>
+        <WebReader
+          webpubManifestUrl={'https://alice.dita.digital/manifest.json'}
+          injectablesReflowable={[
+            {
+              type: 'script',
+              url: `${origin}/js/sample.js`,
+            },
+          ]}
+          injectablesFixed={[]}
+        />
+      </Route>
       <Route path={`${path}/with-reflowable-layout`}>
         <WebReader
           webpubManifestUrl={'https://alice.dita.digital/manifest.json'}

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -49,13 +49,26 @@ const cssInjectables: Injectable[] = [
   },
 ];
 
-const fontInjectable: Injectable = {
-  type: 'style',
-  url: `${origin}/fonts/opendyslexic/opendyslexic.css`,
-  fontFamily: 'opendyslexic',
-};
+const fontInjectable: Injectable[] = [
+  {
+    type: 'style',
+    url: `${origin}/fonts/opendyslexic/opendyslexic.css`,
+    fontFamily: 'opendyslexic',
+  },
+];
 
-const htmlInjectablesReflowable = [...cssInjectables, fontInjectable];
+const scriptInjectable: Injectable[] = [
+  {
+    type: 'script',
+    url: `${origin}/js/sample.js`,
+  },
+];
+
+const htmlInjectablesReflowable = [
+  ...cssInjectables,
+  ...fontInjectable,
+  ...scriptInjectable,
+];
 
 const App = () => {
   /**

--- a/example/static/js/sample.js
+++ b/example/static/js/sample.js
@@ -1,0 +1,3 @@
+document.addEventListener('click', (_) => {
+  console.log('user clicked inside the iframe');
+});

--- a/src/HtmlReader/lib.ts
+++ b/src/HtmlReader/lib.ts
@@ -36,8 +36,19 @@ export function makeInjectableElement(
       return el;
     }
 
+    case 'script': {
+      const el = document.createElement('script');
+      el.setAttribute('type', 'text/javascript');
+      if (injectable.url) {
+        el.setAttribute('src', injectable.url);
+      } else {
+        console.warn('Injectable missing url', injectable);
+      }
+      return el;
+    }
+
     default:
-      return;
+      return undefined;
   }
 }
 


### PR DESCRIPTION
This PR updates the logic to support Javascript injectables.
i.e.
```ts
const injectables = [
  {
    type: "script", // make sure the type is correct
    url: `${origin}/js/sample.js`
  }
];
```

Motive: We need to inject javascript codes on CPW so that we can disable the copy&paste feature on the reader.