### PR TITLE
Refactor Iframe link click

### DIFF
--- a/src/HtmlReader/architecture.md
+++ b/src/HtmlReader/architecture.md
@@ -67,7 +67,7 @@ Note on CFIs: In the future, we would like to support CFIs. These are strings re
 1. `useUpdateScroll`: When the user scrolls freely, we wait for them to stop scrolling and then update dispatch an action to update the `state.location.locations.progression`, keeping the location up to date.
 1. `useLocationQuery`: We now keep a copy of `state.location` sync'd to the `?location` query param in the URL. This allws users to share or save links to specific locations. So we use an effect to update the query whenever `state.location` changes.
 1. `useWindowResize`: When the window resizes, we need to re-scroll the user to the location they are meant to be on. Thus we need to move backwards to the `NavigatingState`.
-1. `useIframeLinkClick`: Uses `React.useEffect` to add a event listener for a "message" event, which is sent from the iframe upon internal link clicks. We then dispatch a `GO_TO_HREF` with the clicked value.
+1. `useIframeLinkClick`: Uses `React.useEffect` to add a event listener for a "message" event, which is sent from the iframe upon internal link clicks. We then dispatch a `GO_TO_HREF` with the clicked value if it's a linkable resource from the webpub manifest. If it's not, we just open the link as a reguar link click on a new tab.
 
 ## Decisions
 

--- a/src/HtmlReader/index.tsx
+++ b/src/HtmlReader/index.tsx
@@ -100,7 +100,7 @@ export default function useHtmlReader(args: ReaderArguments): ReaderReturn {
   useUpdateCSS(state, manifest);
 
   // listen for internal link clicks
-  useIframeLinkClick(dispatch);
+  useIframeLinkClick(webpubManifestUrl, manifest, dispatch);
 
   // dispatch action when arguments change
   React.useEffect(() => {

--- a/src/HtmlReader/lib.ts
+++ b/src/HtmlReader/lib.ts
@@ -98,11 +98,17 @@ export function isSameResource(
   href2: string,
   baseUrl: string
 ): boolean {
-  const url1 = new URL(href1, baseUrl);
-  const url2 = new URL(href2, baseUrl);
-  const doMatch =
-    url1.origin === url2.origin && url1.pathname === url2.pathname;
-  return doMatch;
+  try {
+    const url1 = new URL(href1, baseUrl);
+    const url2 = new URL(href2, baseUrl);
+    const doMatch =
+      url1.origin === url2.origin && url1.pathname === url2.pathname;
+    return doMatch;
+  } catch (e) {
+    console.error(e);
+  }
+
+  return false;
 }
 
 /**

--- a/src/HtmlReader/useIframeLinkClick.ts
+++ b/src/HtmlReader/useIframeLinkClick.ts
@@ -1,17 +1,46 @@
 import React from 'react';
+import { WebpubManifest } from '../WebpubManifestTypes/WebpubManifest';
+import { getFromReadingOrder } from './lib';
 import { HtmlAction } from './types';
 
 export default function useIframeLinkClick(
+  baseUrl: string | undefined,
+  manifest: WebpubManifest | undefined,
   dispatch: React.Dispatch<HtmlAction>
 ): void {
   React.useEffect(() => {
+    if (!baseUrl || !manifest) return;
     window.addEventListener('message', ({ data }) => {
       if (typeof data === 'object' && data !== null && 'type' in data) {
         switch (data.type) {
           case 'LINK_CLICKED':
-            dispatch({ type: 'GO_TO_HREF', href: data.href });
+            handleIframeLink(data.href, manifest, baseUrl, dispatch);
         }
       }
     });
-  }, [dispatch]);
+  }, [dispatch, baseUrl, manifest]);
 }
+
+const handleIframeLink = (
+  href: string,
+  manifest: WebpubManifest,
+  baseUrl: string,
+  dispatch: React.Dispatch<HtmlAction>
+) => {
+  if (isExternalLink(href, manifest, baseUrl)) {
+    window.open(href, '_blank');
+  } else {
+    dispatch({ type: 'GO_TO_HREF', href: href });
+  }
+};
+
+// If the href doesn't exist in the readingOrder, it's not
+// part of the book link, we can say this is an external link
+const isExternalLink = (
+  href: string,
+  manifest: WebpubManifest,
+  baseUrl: string
+) => {
+  const resource = getFromReadingOrder(href, manifest, baseUrl);
+  return resource === undefined;
+};

--- a/src/HtmlReader/useResource.tsx
+++ b/src/HtmlReader/useResource.tsx
@@ -108,8 +108,11 @@ function injectJS(body: HTMLElement) {
       function handleLinkClick(evt) {
         // don't navigate
         evt.preventDefault();
-        // send message to parent
-        window.parent.postMessage( { type: 'LINK_CLICKED', href: evt.target.href } );
+        const  href = evt.currentTarget.href;
+        if(href) {
+          // send message to parent
+          window.parent.postMessage( { type: 'LINK_CLICKED', href  } );
+        }
       };
       for ( var i = 0; i < links.length; i ++ ) {
         links[i].addEventListener('click', handleLinkClick);


### PR DESCRIPTION
This PR fixes the bug where sometimes when the user clicks on an anchor tag from the book content, it throws the "invalid URL" error. This is because some of the `<a>` tags in the book do not come with a href value, therefore, when constructing a URL with the href value via `new URL(href)`,  we get a type error.

There are a couple of changes in this PR:

- We should check to ensure the `<a>` tag contains a href value in our handleLinkClick function. `<a>` without the href attribute is semantically correct and valid according to the [HTML standard](https://www.w3.org/TR/2016/REC-html51-20161101/textlevel-semantics.html#the-a-element). So we will just let it pass through if it's missing the href. Otherwise, we perform our normal link click action.
- Changing the code to use `evt.currentTarget` to get the href value in our event listener, because sometimes there are nested elements inside the anchor element.
- While fixing the bug, I realized that our app only recognizes links that are from the book(TOC), while others, like https://google.com was ignored. I added a function to detect if the clicked link is a valid resource from the book; if not, we just open the link in a separate tab.

