### PR TITLE
Cleanup side effects for link handler event

### DIFF
--- a/src/HtmlReader/useIframeLinkClick.ts
+++ b/src/HtmlReader/useIframeLinkClick.ts
@@ -10,14 +10,19 @@ export default function useIframeLinkClick(
 ): void {
   React.useEffect(() => {
     if (!baseUrl || !manifest) return;
-    window.addEventListener('message', ({ data }) => {
+
+    const messageHandler = ({ data }: { data: MessageEvent['data'] }) => {
       if (typeof data === 'object' && data !== null && 'type' in data) {
         switch (data.type) {
           case 'LINK_CLICKED':
             handleIframeLink(data.href, manifest, baseUrl, dispatch);
         }
       }
-    });
+    };
+
+    window.addEventListener('message', messageHandler);
+
+    return () => window.removeEventListener('message', messageHandler);
   }, [dispatch, baseUrl, manifest]);
 }
 
@@ -27,6 +32,7 @@ const handleIframeLink = (
   baseUrl: string,
   dispatch: React.Dispatch<HtmlAction>
 ) => {
+  console.log(isExternalLink(href, manifest, baseUrl));
   if (isExternalLink(href, manifest, baseUrl)) {
     window.open(href, '_blank');
   } else {

--- a/src/HtmlReader/useIframeLinkClick.ts
+++ b/src/HtmlReader/useIframeLinkClick.ts
@@ -32,7 +32,6 @@ const handleIframeLink = (
   baseUrl: string,
   dispatch: React.Dispatch<HtmlAction>
 ) => {
-  console.log(isExternalLink(href, manifest, baseUrl));
   if (isExternalLink(href, manifest, baseUrl)) {
     window.open(href, '_blank');
   } else {


### PR DESCRIPTION
This PR fixes a bug where a new eventListener is registered every time users open a new book because we never clean up the eventListener after the component is unmounted. Resulting in when sometimes a link should be navigation within the book but instead opens the link in a new tab.