### PR TITLE
Fix popper

### DIFF
--- a/src/ui/SettingsButton.tsx
+++ b/src/ui/SettingsButton.tsx
@@ -6,6 +6,8 @@ import {
   PopoverBody,
   Text,
   Icon,
+  Portal,
+  Box,
 } from '@chakra-ui/react';
 import { PDFActiveReader, HTMLActiveReader } from '../types';
 
@@ -46,12 +48,14 @@ export default function SettingsCard(
     <>
       <Popover
         gutter={0}
-        placement="bottom-end"
+        placement="bottom-start"
         isOpen={isOpen}
         onOpen={open}
         onClose={close}
-        offset={[-200, 0]}
+        // offset={[-200, 0]}
         autoFocus={true}
+        preventOverflow
+        strategy="fixed"
       >
         <PopoverTrigger>
           <Button
@@ -64,12 +68,14 @@ export default function SettingsCard(
           </Button>
         </PopoverTrigger>
         <PopoverContent
+          overflow="hidden"
           bgColor={contentBgColor}
           borderRadius="0 0 4px 4px"
           boxShadow="0 4px 4px -2px #424242"
-          minWidth="fit-content"
+          width="inherit"
+          maxWidth="100vw"
         >
-          <PopoverBody p={0} maxWidth="100vw">
+          <PopoverBody p={0}>
             {props.type === 'PDF' && (
               <PdfSettings
                 // Destructuring props before type check causes Typescript warning.


### PR DESCRIPTION
Basically the issue was that Popper.js (used by chakra) is depending on the width of the element to calculate its position. The width of the element by default was quite small and our content overflowed. Therefore, we set `minWidth="fit-content"`. However, setting a `minWidth` in css doesn't change the element's `width`. So when popper.js went to get the `width`, it was still that initial smaller width. 

I just swapped out `minWidth="fit-content"` for `width="inherit"`. I also moved the `maxWidth="100vw"` to this element. Finally, I saw a reference in Popper.js documentation that `strategy="fixed" makes the popover less jittery if your anchor element is fixed, which ours is (well it's not technically position fixed I don't think but it stays in the same place always so it basically is). So I set that and it does seem less jittery when resizing the page.