### PR TITLE
SFR-1524/1525: Implement PDF ToC component 

### DIFF
--- a/src/PdfReader/generateSinglePdfToc.tsx
+++ b/src/PdfReader/generateSinglePdfToc.tsx
@@ -14,8 +14,8 @@ export default async function generateSinglePdfToc(
     const outline = await pdf.getOutline(); // get the TOC outline
 
     if (outline) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const addTocItem = async (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         outline: any[],
         tocItems: PdfTocItem[]
       ): Promise<PdfTocItem[]> => {

--- a/src/PdfReader/generateSinglePdfToc.tsx
+++ b/src/PdfReader/generateSinglePdfToc.tsx
@@ -1,9 +1,5 @@
 import { pdfjs } from 'react-pdf';
-
-type PdfTocItem = {
-  title: string;
-  pageNumber: number;
-};
+import { PdfTocItem } from '../types';
 
 /**
  * Retrieve TOC data from single-resource PDF using PDF.js
@@ -13,31 +9,46 @@ type PdfTocItem = {
 export default async function generateSinglePdfToc(
   proxiedUrl: string
 ): Promise<PdfTocItem[]> {
-  const tocItems: PdfTocItem[] = [];
   try {
     const pdf = await pdfjs.getDocument(proxiedUrl).promise;
     const outline = await pdf.getOutline(); // get the TOC outline
 
     if (outline) {
-      // iterate through each chapter
-      for (let i = 0; i < outline.length; i++) {
-        const dest = outline[i].dest;
-        if (dest && dest.length > 0) {
-          // get the page referance
-          const ref = dest[0];
-          const pageIndex = await pdf.getPageIndex(ref);
-          if (pageIndex) {
-            tocItems.push({
-              title: outline[i].title,
-              pageNumber: pageIndex + 1,
-            });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const addTocItem = async (
+        outline: any[],
+        tocItems: PdfTocItem[]
+      ): Promise<PdfTocItem[]> => {
+        // iterate through each chapter
+        for (let i = 0; i < outline.length; i++) {
+          const chapter = outline[i];
+          const dest = chapter.dest;
+          if (dest && dest.length > 0) {
+            // get the page referance
+            const ref = dest[0];
+            const pageIndex = await pdf.getPageIndex(ref);
+            let subChapters: PdfTocItem[] = [];
+            const outlineChildren = chapter.items;
+            if (outlineChildren.length > 0) {
+              subChapters = await addTocItem(outlineChildren, []);
+            }
+            if (pageIndex) {
+              tocItems.push({
+                title: chapter.title,
+                pageNumber: pageIndex + 1,
+                children: subChapters,
+              });
+            }
           }
         }
-      }
+        return Promise.all(tocItems);
+      };
+
+      return await addTocItem(outline, []);
     }
   } catch (e) {
     console.error(e); // todo: add error handling
   }
 
-  return Promise.all(tocItems);
+  return [];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type Navigator = {
   goBackward: () => void;
   setScroll: (val: 'scrolling' | 'paginated') => Promise<void>;
   goToPage: (href: string) => void;
+  goToPageNumber?: (pageNumber: number) => void;
 };
 
 export type PdfNavigator = Navigator & {
@@ -50,6 +51,7 @@ export type ReaderState = {
   atEnd: boolean;
   location?: Locator;
   settings: ReaderSettings | undefined;
+  singlePdfToc?: PdfTocItem[];
 };
 
 export type InactiveReader = null;
@@ -145,3 +147,9 @@ export type InactiveReaderArguments = undefined;
 export type ReaderArguments = ActiveReaderArguments | InactiveReaderArguments;
 
 export type GetColor = (light: string, dark: string, sepia: string) => string;
+
+export type PdfTocItem = {
+  title: string;
+  pageNumber: number;
+  children: PdfTocItem[];
+};

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -6,7 +6,8 @@ import useColorModeValue from '../ui/hooks/useColorModeValue';
 
 import SettingsCard from './SettingsButton';
 import Button from './Button';
-import TableOfContent from './TableOfContent';
+import TableOfContent from './toc/TableOfContent';
+import PdfTableOfContent from './toc/PdfTableOfContent';
 import { MdOutlineFullscreenExit, MdOutlineFullscreen } from 'react-icons/md';
 import useFullscreen from './hooks/useFullScreen';
 import { HEADER_HEIGHT } from '../constants';
@@ -44,18 +45,28 @@ export default function Header(
     }
 ): React.ReactElement {
   const [isFullscreen, toggleFullScreen] = useFullscreen();
-  const { headerLeft, navigator, manifest, containerRef } = props;
+  const { headerLeft, navigator, manifest, containerRef, state } = props;
   const mainBgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
 
   return (
     <HeaderWrapper bg={mainBgColor}>
       {headerLeft ?? <DefaultHeaderLeft />}
       <HStack ml="auto" spacing={1}>
-        <TableOfContent
-          containerRef={containerRef}
-          navigator={navigator}
-          manifest={manifest}
-        />
+        {state.singlePdfToc && state.singlePdfToc.length > 0 && (
+          <PdfTableOfContent
+            containerRef={containerRef}
+            navigator={navigator}
+            tocItems={state.singlePdfToc}
+          />
+        )}
+        {!state.singlePdfToc ||
+          (state.singlePdfToc.length === 0 && (
+            <TableOfContent
+              containerRef={containerRef}
+              navigator={navigator}
+              manifest={manifest}
+            />
+          ))}
         <SettingsCard {...props} />
         <Button
           border="none"

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -59,14 +59,13 @@ export default function Header(
             tocItems={state.singlePdfToc}
           />
         )}
-        {!state.singlePdfToc ||
-          (state.singlePdfToc.length === 0 && (
-            <TableOfContent
-              containerRef={containerRef}
-              navigator={navigator}
-              manifest={manifest}
-            />
-          ))}
+        {(!state.singlePdfToc || state.singlePdfToc.length === 0) && (
+          <TableOfContent
+            containerRef={containerRef}
+            navigator={navigator}
+            manifest={manifest}
+          />
+        )}
         <SettingsCard {...props} />
         <Button
           border="none"

--- a/src/ui/theme/components/toc.ts
+++ b/src/ui/theme/components/toc.ts
@@ -1,0 +1,25 @@
+const baseStyle = {
+  menuList: {
+    overflowY: 'auto',
+    m: '0',
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    right: '0',
+    bottom: '0',
+    zIndex: 'overlay',
+    border: 'none',
+    borderRadius: '0',
+  },
+  icon: {
+    w: 6,
+    h: 6,
+  },
+};
+
+const TableOfContent = {
+  parts: ['menuList', 'icon'],
+  baseStyle,
+};
+
+export default TableOfContent;

--- a/src/ui/theme/index.ts
+++ b/src/ui/theme/index.ts
@@ -7,6 +7,7 @@ import { getColor } from '../../utils/getColor';
 import getButtonStyle from './components/button';
 import Alert from './components/alert';
 import { Dict } from './types';
+import TableOfContent from './components/toc';
 
 /**
  * See Chakra default theme for shape of theme object:
@@ -29,6 +30,7 @@ export function getTheme(colorMode: ColorMode = 'day'): Dict<unknown> {
         Button: getButtonStyle(getColor(colorMode)),
         Text,
         Alert,
+        TableOfContent,
       },
       currentColorMode: colorMode,
     },

--- a/src/ui/toc/Item.tsx
+++ b/src/ui/toc/Item.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import useColorModeValue from '../hooks/useColorModeValue';
+import { MenuItem } from '../menu';
+
+export const Item = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentProps<typeof MenuItem> & { html: string }
+>(({ html, children, ...props }, ref) => {
+  const bgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
+  const color = useColorModeValue('ui.black', 'ui.white', 'ui.black');
+  const borderColor = useColorModeValue(
+    'ui.gray.medium',
+    'gray.500',
+    'yellow.600'
+  );
+
+  const _hover = {
+    textDecoration: 'none',
+    background: 'ui.gray.x-dark',
+    color: 'ui.white',
+  } as const;
+
+  const _focus = {
+    ..._hover,
+    boxShadow: 'none',
+  } as const;
+
+  return (
+    <>
+      <MenuItem
+        d="flex"
+        flexDir="column"
+        alignItems="stretch"
+        listStyleType="none"
+        bg={bgColor}
+        color={color}
+        _hover={_hover}
+        _focus={_focus}
+        tabIndex={-1}
+        borderBottom="1px solid"
+        borderColor={borderColor}
+        {...props}
+      >
+        <span dangerouslySetInnerHTML={{ __html: html }} />
+      </MenuItem>
+      {children}
+    </>
+  );
+});

--- a/src/ui/toc/MissingToc.tsx
+++ b/src/ui/toc/MissingToc.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@chakra-ui/react';
+import React from 'react';
+
+export const MissingToc = ({
+  children,
+}: {
+  children: string | React.ReactElement;
+}): React.ReactElement => {
+  return (
+    <Box
+      d="flex"
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+      maxHeight="100vmin"
+    >
+      {children}
+    </Box>
+  );
+};

--- a/src/ui/toc/PdfTableOfContent.tsx
+++ b/src/ui/toc/PdfTableOfContent.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Portal, Text, Icon, useMultiStyleConfig } from '@chakra-ui/react';
+import { MdOutlineToc, MdOutlineCancel } from 'react-icons/md';
+import { Navigator, PdfTocItem } from '../../types';
+import Button from '../Button';
+import useColorModeValue from '../hooks/useColorModeValue';
+import { Menu, MenuButton, MenuList } from '../menu';
+import { Item } from './Item';
+import { MissingToc } from './MissingToc';
+
+export default function PdfTableOfContent({
+  navigator,
+  tocItems,
+  containerRef,
+}: {
+  navigator: Navigator;
+  tocItems: PdfTocItem[];
+  containerRef: React.MutableRefObject<HTMLDivElement | null>;
+}): React.ReactElement {
+  const tocLinkHandler = (pageNumber: number) => {
+    if (navigator.goToPageNumber) {
+      navigator.goToPageNumber(pageNumber);
+    }
+  };
+  const tocBgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
+  const styles = useMultiStyleConfig('TableOfContent', {});
+
+  return (
+    <Menu>
+      {({ isOpen }) => (
+        <>
+          <MenuButton
+            as={Button}
+            border="none"
+            aria-label="Table of Contents"
+            leftIcon={
+              <Icon
+                as={isOpen ? MdOutlineCancel : MdOutlineToc}
+                sx={styles.icon}
+              />
+            }
+          >
+            <Text variant="headerNav">Table of Contents</Text>
+          </MenuButton>
+          <Portal containerRef={containerRef}>
+            <MenuList sx={styles.menuList} bg={tocBgColor}>
+              {tocItems && tocItems.length > 0 ? (
+                tocItems.map((item: PdfTocItem, i) => (
+                  <Item
+                    key={item.title}
+                    aria-label={item.title}
+                    onClick={() => tocLinkHandler(item.pageNumber)}
+                    html={item.title ?? ''}
+                  >
+                    {item.children && (
+                      <>
+                        {item.children.map((subLink) => (
+                          <Item
+                            aria-label={subLink.title}
+                            key={subLink.title}
+                            onClick={() => tocLinkHandler(subLink.pageNumber)}
+                            pl={10}
+                            html={subLink.title ?? ''}
+                          ></Item>
+                        ))}
+                      </>
+                    )}
+                  </Item>
+                ))
+              ) : (
+                <MissingToc>
+                  This publication does not have a Table of Contents.
+                </MissingToc>
+              )}
+            </MenuList>
+          </Portal>
+        </>
+      )}
+    </Menu>
+  );
+}

--- a/src/ui/toc/TableOfContent.tsx
+++ b/src/ui/toc/TableOfContent.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { Portal, Text, Icon, Box } from '@chakra-ui/react';
+import { Portal, Text, Icon, useMultiStyleConfig } from '@chakra-ui/react';
 import { MdOutlineToc, MdOutlineCancel } from 'react-icons/md';
-import { Navigator, WebpubManifest } from '../types';
-import Button from './Button';
-import useColorModeValue from './hooks/useColorModeValue';
-import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
-import { Menu, MenuButton, MenuItem, MenuList } from './menu';
+import { Navigator, WebpubManifest } from '../../types';
+import Button from '../Button';
+import useColorModeValue from '../hooks/useColorModeValue';
+import { ReadiumLink } from '../../WebpubManifestTypes/ReadiumLink';
+import { Menu, MenuButton, MenuList } from '../menu';
+import { Item } from './Item';
+import { MissingToc } from './MissingToc';
 
 export default function TableOfContent({
   navigator,
@@ -20,6 +22,7 @@ export default function TableOfContent({
     navigator.goToPage(href);
   };
   const tocBgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
+  const styles = useMultiStyleConfig('TableOfContent', {});
 
   const getLinkHref = (link: ReadiumLink): string => {
     if (link.href) return link.href;
@@ -36,25 +39,16 @@ export default function TableOfContent({
             border="none"
             aria-label="Table of Contents"
             leftIcon={
-              <Icon as={isOpen ? MdOutlineCancel : MdOutlineToc} w={6} h={6} />
+              <Icon
+                as={isOpen ? MdOutlineCancel : MdOutlineToc}
+                sx={styles.icon}
+              />
             }
           >
             <Text variant="headerNav">Table of Contents</Text>
           </MenuButton>
           <Portal containerRef={containerRef}>
-            <MenuList
-              overflowY="auto"
-              m="0"
-              position="absolute"
-              top="0"
-              left="0"
-              bg={tocBgColor}
-              right="0"
-              bottom="0"
-              zIndex="overlay"
-              border="none"
-              borderRadius="0"
-            >
+            <MenuList sx={styles.menuList} bg={tocBgColor}>
               {manifest.toc && manifest.toc.length > 0 ? (
                 manifest.toc.map((content: ReadiumLink, i) => (
                   <Item
@@ -90,67 +84,3 @@ export default function TableOfContent({
     </Menu>
   );
 }
-
-const MissingToc = ({
-  children,
-}: {
-  children: string | React.ReactElement;
-}) => {
-  return (
-    <Box
-      d="flex"
-      justifyContent="center"
-      alignItems="center"
-      height="100%"
-      maxHeight="100vmin"
-    >
-      {children}
-    </Box>
-  );
-};
-
-const Item = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentProps<typeof MenuItem> & { html: string }
->(({ html, children, ...props }, ref) => {
-  const bgColor = useColorModeValue('ui.white', 'ui.black', 'ui.sepia');
-  const color = useColorModeValue('ui.black', 'ui.white', 'ui.black');
-  const borderColor = useColorModeValue(
-    'ui.gray.medium',
-    'gray.500',
-    'yellow.600'
-  );
-
-  const _hover = {
-    textDecoration: 'none',
-    background: 'ui.gray.x-dark',
-    color: 'ui.white',
-  } as const;
-
-  const _focus = {
-    ..._hover,
-    boxShadow: 'none',
-  } as const;
-
-  return (
-    <>
-      <MenuItem
-        d="flex"
-        flexDir="column"
-        alignItems="stretch"
-        listStyleType="none"
-        bg={bgColor}
-        color={color}
-        _hover={_hover}
-        _focus={_focus}
-        tabIndex={-1}
-        borderBottom="1px solid"
-        borderColor={borderColor}
-        {...props}
-      >
-        <span dangerouslySetInnerHTML={{ __html: html }} />
-      </MenuItem>
-      {children}
-    </>
-  );
-});

--- a/tests/PdfTableOfContent.test.tsx
+++ b/tests/PdfTableOfContent.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import PdfTableOfContent from '../src/ui/toc/PdfTableOfContent';
+import { MockNavigator, MockSinglePdfTocItems } from './utils/MockData';
+
+import { axe } from 'jest-axe';
+
+const TestTOC: React.FC<
+  Omit<React.ComponentProps<typeof PdfTableOfContent>, 'containerRef'>
+> = (props) => {
+  const ref = React.useRef();
+  return (
+    <div ref={ref}>
+      <PdfTableOfContent containerRef={ref} {...props} />
+    </div>
+  );
+};
+
+describe('Table of Content Accessibility checker', () => {
+  test('TOC should have no violation', async () => {
+    const { container } = render(
+      <TestTOC navigator={MockNavigator} tocItems={MockSinglePdfTocItems} />
+    );
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('Empty Table of Content', () => {
+  test('Empty TOC should show the missing toc message to users', () => {
+    const MissingTocItems = [];
+    render(<TestTOC navigator={MockNavigator} tocItems={MissingTocItems} />);
+
+    expect(
+      screen.queryByText(/This publication does not have a Table of Contents/)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Table Of Content rendering', () => {
+  beforeEach(() => {
+    render(
+      <TestTOC navigator={MockNavigator} tocItems={MockSinglePdfTocItems} />
+    );
+  });
+
+  test('render Table Of Content', async () => {
+    // The initial TOC component render should not show TOC popover on the screen.
+    expect(screen.queryByText('Chapter 1')).not.toBeVisible();
+
+    // We need to open the TOC element for TOC links to show up
+    const toggleBtn = screen.getByRole('button', { name: 'Table of Contents' });
+    fireEvent.click(toggleBtn);
+
+    const tocLinkElm = await screen.findByRole('menuitem', {
+      name: 'Chapter 1',
+    });
+    expect(tocLinkElm).toBeInTheDocument();
+  });
+
+  test('navigation should be called with the correct url', async () => {
+    const toggleBtn = screen.getByRole('button', { name: 'Table of Contents' });
+    fireEvent.click(toggleBtn);
+
+    const chapterOneElm = await screen.findByRole('menuitem', {
+      name: 'Chapter 1',
+    });
+    fireEvent.click(chapterOneElm);
+    expect(MockNavigator.goToPageNumber).toHaveBeenCalledWith(9);
+  });
+
+  test('navigation should call chapter and subchapters separately if both are provided', async () => {
+    const toggleBtn = screen.getByRole('button', { name: 'Table of Contents' });
+    fireEvent.click(toggleBtn);
+
+    const chapterTwoElm = await screen.findByRole('menuitem', {
+      name: 'Chapter 2',
+    });
+    fireEvent.click(chapterTwoElm);
+    expect(MockNavigator.goToPageNumber).toHaveBeenCalledWith(19);
+
+    fireEvent.click(toggleBtn);
+
+    const chapterTwoTwoElm = await screen.findByRole('menuitem', {
+      name: 'Chapter 2 Section 2',
+    });
+    fireEvent.click(chapterTwoTwoElm);
+    expect(MockNavigator.goToPageNumber).toHaveBeenCalledWith(26);
+  });
+});

--- a/tests/TableOfContent.test.tsx
+++ b/tests/TableOfContent.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import TableOfContent from '../src/ui/TableOfContent';
+import TableOfContent from '../src/ui/toc/TableOfContent';
 import { MockNavigator, MockWebpubManifest } from './utils/MockData';
 
 import { axe } from 'jest-axe';

--- a/tests/utils/MockData.tsx
+++ b/tests/utils/MockData.tsx
@@ -7,6 +7,7 @@ import {
   WebpubManifest,
   FontFamily,
   ColorMode,
+  PdfTocItem,
 } from '../../src/types';
 import { HtmlSettingsProps } from '../../src/ui/HtmlSettings';
 import { PdfSettingsProps } from '../../src/ui/PdfSettings';
@@ -21,6 +22,7 @@ const zoomInFn = jest.fn();
 const zoomOutFn = jest.fn();
 const setFontFamilyFn = jest.fn();
 const goToPageFn = jest.fn();
+const goToPageNumberFn = jest.fn();
 
 export const MockNavigator = {
   goForward: goForwardFn,
@@ -31,6 +33,7 @@ export const MockNavigator = {
   decreaseFontSize: decreaseFontSizeFn,
   setFontFamily: setFontFamilyFn,
   goToPage: goToPageFn,
+  goToPageNumber: goToPageNumberFn,
 } as Navigator;
 
 export const MockHtmlNavigator = {
@@ -145,6 +148,50 @@ export const MockWebpubManifest = {
     },
   ],
 } as WebpubManifest;
+
+export const MockSinglePdfTocItems = [
+  {
+    title: 'Chapter 1',
+    pageNumber: 9,
+    children: [],
+  },
+  {
+    title: 'Chapter 2',
+    pageNumber: 19,
+    children: [
+      {
+        title: 'Chapter 2 Section 1',
+        pageNumber: 20,
+        children: [],
+      },
+      {
+        title: 'Chapter 2 Section 2',
+        pageNumber: 26,
+        children: [],
+      },
+      {
+        title: 'Chapter 2 Section 3',
+        pageNumber: 30,
+        children: [],
+      },
+      {
+        title: 'Chapter 2 Section 4',
+        pageNumber: 36,
+        children: [],
+      },
+    ],
+  },
+  {
+    title: 'Chapter 3',
+    pageNumber: 42,
+    children: [],
+  },
+  {
+    title: 'Chapter 4',
+    pageNumber: 58,
+    children: [],
+  },
+] as PdfTocItem[];
 
 const MockComponent = (): React.ReactElement => <>Hello, world.</>;
 


### PR DESCRIPTION
[SFR-1524](https://jira.nypl.org/browse/SFR-1524) and [SFR-1525](https://jira.nypl.org/browse/SFR-1525)

This PR does the following:
- Adds functionality to get the sub-chapters to `generateSinglePdfToc`.
- Pulls the styles from `TableOfContent` into a theme file to be reused in `PdfTableOfContent`.
- Separates `MissingToc` and `Item` into individual files.
- Implements `PdfTableOfContent` in the `Header`.