### PR TITLE
Adds workaround for Chakra/Safari bug

### DIFF
--- a/src/ui/SettingsButton.tsx
+++ b/src/ui/SettingsButton.tsx
@@ -40,10 +40,11 @@ export default function SettingsCard(
     <>
       <Popover
         gutter={0}
+        closeOnBlur
         placement="bottom-start"
         isOpen={isOpen}
-        onOpen={open}
         onClose={close}
+        onOpen={open}
         autoFocus={true}
         preventOverflow
         strategy="fixed"
@@ -51,6 +52,9 @@ export default function SettingsCard(
         <PopoverTrigger>
           <Button
             onClick={open}
+            onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
+              e.preventDefault()
+            }
             border="none"
             aria-label="Settings"
             leftIcon={<Icon as={ReaderSettings} w={6} h={6} fill={iconFill} />}

--- a/src/ui/SettingsButton.tsx
+++ b/src/ui/SettingsButton.tsx
@@ -52,6 +52,14 @@ export default function SettingsCard(
         <PopoverTrigger>
           <Button
             onClick={open}
+            /**
+             * preventDefault fixes a Chakra bug where in Safari,
+             * the PopoverTrigger will not close the Popover.
+             * The issue is described in
+             * https://github.com/chakra-ui/chakra-ui/issues/3461
+             * and the workaround can be found in
+             * https://github.com/chakra-ui/chakra-ui/issues/587.
+             * */
             onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
               e.preventDefault()
             }


### PR DESCRIPTION
Added a workaround to fix Chakra bug where Settings button would open, but not close, the popover. 
Everything is still working as expected in Chrome with this change.

Issue is talked about in various places, including: https://github.com/chakra-ui/chakra-ui/issues/3461
Used a solution that works for the Menu component found here: https://github.com/chakra-ui/chakra-ui/issues/587

Resolves Jira ticket OE-774: https://jira.nypl.org/browse/OE-774