### PR TITLE
Kristo/pdf-toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,55 @@ const Reader = () => {
 
 We make every effort to throw useful errors. Your app should probably wrap the web reader component in a React `<ErrorBoundary>` to either display the thrown errors or a custom error state for your users in the case one is thrown. See the example app for an example using an Error Boundary.
 
+## Modifying PDF Manifests
+
+In some cases it may be desirable to modify the Webpub Manifest before passing it to the web reader. One example of this is with single-resource PDFs. These manifests sometimes arrive without a table of contents. The information for the TOC is embedded in the single PDF file itself. In this situation, we have set up a utility to extract the PDF TOC and add it to the manifest. There is an example of this working at []`/pdf/single-resource-short`](https://nypl-web-reader.vercel.app/pdf/single-resource-short).
+
+In order to make this work in your app, you will want to:
+
+1. Fetch your manifest
+1. Use `addTocToManifest` to add the table of contents
+1. Generate a synthetic URL for the in-memory JSON object
+1. Pass this generated URL to the web reader.
+
+<details>
+<summary>See the example code</summary>
+
+```ts
+const fetchAndModifyManifest: Fetcher<string, string> = async (url) => {
+  const response = await fetch(url);
+  const manifest = await response.json();
+  const modifiedManifest = await addTocToManifest(
+    manifest,
+    getProxiedResource(pdfProxyUrl),
+    pdfWorkerSrc
+  );
+  const syntheticUrl = URL.createObjectURL(
+    new Blob([JSON.stringify(modifiedManifest)])
+  );
+  return syntheticUrl;
+};
+
+const SingleResourcePdf = () => {
+  const { data: modifiedManifestUrl, isLoading } = useSWR<string>(
+    '/samples/pdf/single-resource-short.json',
+    fetchAndModifyManifest
+  );
+
+  if (isLoading || !modifiedManifestUrl) return <div>Loading...</div>;
+
+  return (
+    <WebReader
+      webpubManifestUrl={modifiedManifestUrl}
+      proxyUrl={pdfProxyUrl}
+      pdfWorkerSrc={`${origin}/pdf-worker/pdf.worker.min.js`}
+    />
+  );
+};
+```
+
+</details>
+
 # Development
 
 ## Architecture

--- a/cypress/integration/multi-pdf/navigations.ts
+++ b/cypress/integration/multi-pdf/navigations.ts
@@ -28,9 +28,7 @@ describe('Multi PDF navigation', () => {
     cy.findByRole('button', { name: 'Table of Contents' }).click();
     cy.findByRole('menuitem', { name: 'Foreword' }).click();
     cy.wait('@pdf');
-    cy.findByText('Anthropology without Informants', { timeout: 10000 }).should(
-      'be.visible'
-    );
+    cy.findAllByText(/Foreword/, { timeout: 10000 }).should('be.visible');
     cy.get('div[data-page-number="2"]').should('exist');
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "@emotion/styled": "^11.8.1",
         "react": "^16.8.0 || 17.x || 18.x",
         "react-dom": "^16.8.0 || 17.x || 18.x",
-        "swr": "^1.0.1"
+        "swr": "^2.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -32747,14 +32747,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
-    "node_modules/dequal": {
-      "version": "2.0.2",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
@@ -50124,14 +50116,18 @@
       }
     },
     "node_modules/swr": {
-      "version": "1.0.1",
-      "integrity": "sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.3.tgz",
+      "integrity": "sha512-sGvQDok/AHEWTPfhUWXEHBVEXmgGnuahyhmRQbjl9XBYxT/MSlAzvXEKQpyM++bMPaI52vcWS2HiKNaW7+9OFw==",
       "peer": true,
       "dependencies": {
-        "dequal": "2.0.2"
+        "use-sync-external-store": "^1.2.0"
+      },
+      "engines": {
+        "pnpm": "7"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -51893,6 +51889,15 @@
       "version": "1.14.1",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "peer": true
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -76587,11 +76592,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
-    "dequal": {
-      "version": "2.0.2",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "peer": true
-    },
     "des.js": {
       "version": "1.0.1",
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
@@ -89606,11 +89606,12 @@
       }
     },
     "swr": {
-      "version": "1.0.1",
-      "integrity": "sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.3.tgz",
+      "integrity": "sha512-sGvQDok/AHEWTPfhUWXEHBVEXmgGnuahyhmRQbjl9XBYxT/MSlAzvXEKQpyM++bMPaI52vcWS2HiKNaW7+9OFw==",
       "peer": true,
       "requires": {
-        "dequal": "2.0.2"
+        "use-sync-external-store": "^1.2.0"
       }
     },
     "symbol-tree": {
@@ -90843,6 +90844,13 @@
           "peer": true
         }
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peer": true,
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@emotion/styled": "^11.8.1",
     "react": "^16.8.0 || 17.x || 18.x",
     "react-dom": "^16.8.0 || 17.x || 18.x",
-    "swr": "^1.0.1"
+    "swr": "^2.0.3"
   },
   "prettier": {
     "printWidth": 80,

--- a/src/PdfReader/addTocToManifest.tsx
+++ b/src/PdfReader/addTocToManifest.tsx
@@ -21,11 +21,14 @@ export default async function addTocToManifest(
       if (dest && dest.length > 0) {
         // get the page referance
         const ref = dest[0];
-        const pageIndex = await pdf.getPageIndex(ref);
+        // the return value is improperly typed in the pdfjs library, and so we have to cast it here.
+        const pageIndex = ((await pdf.getPageIndex(ref)) as unknown) as number;
+        // just in case the above cast is incorrect, we will check that pageIndex is a number
+        if (typeof pageIndex !== 'number') return undefined;
         if (pageIndex) {
           const link: ReadiumLink = {
             title: chapter.title,
-            href: `${pdfUrl}#page=${pageIndex.num + 1}`,
+            href: `${pdfUrl}#page=${pageIndex + 1}`,
             children: [],
           };
           return link;

--- a/src/PdfReader/addTocToManifest.tsx
+++ b/src/PdfReader/addTocToManifest.tsx
@@ -41,7 +41,7 @@ export default async function addTocToManifest(
       }
       return undefined;
     });
-    // await all the promises and filter any undefined values (tere was no chapter.dest or pageIndex)
+    // await all the promises and filter any undefined values (there was no chapter.dest or pageIndex)
     const toc = (await Promise.all(tocPromises)).filter(
       (item): item is ReadiumLink => !!item
     );

--- a/src/PdfReader/addTocToManifest.tsx
+++ b/src/PdfReader/addTocToManifest.tsx
@@ -1,39 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { pdfjs } from 'react-pdf';
 import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
 import { WebpubManifest } from '../types';
-
-const addTocItem = async (
-  pdf: any,
-  outline: any[],
-  pdfUrl: string,
-  tocItems: ReadiumLink[]
-): Promise<ReadiumLink[]> => {
-  // iterate through each chapter
-  for (let i = 0; i < outline.length; i++) {
-    const chapter = outline[i];
-    const dest = chapter.dest;
-    if (dest && dest.length > 0) {
-      // get the page referance
-      const ref = dest[0];
-      const pageIndex = await pdf.getPageIndex(ref);
-      // TODO: Uncomment subchapter handling when goToPage is updated
-      // let subChapters: ReadiumLink[] = [];
-      // const outlineChildren = chapter.items;
-      // if (outlineChildren.length > 0) {
-      //   subChapters = await addTocItem(pdf, outlineChildren, pdfUrl, []);
-      // }
-      if (pageIndex) {
-        tocItems.push({
-          title: chapter.title,
-          href: `${pdfUrl}#page=${pageIndex + 1}`,
-          children: [], // TODO: replace with subChapters when goToPage is updated
-        });
-      }
-    }
-  }
-  return Promise.all(tocItems);
-};
 
 /**
  * Adds TOC data to Webpub Manifest from single-resource PDF using PDF.js
@@ -49,10 +16,27 @@ export default async function addTocToManifest(
   try {
     const pdf = await pdfjs.getDocument(proxiedUrl).promise;
     const outline = await pdf.getOutline(); // get the TOC outline
-    let toc: ReadiumLink[] = [];
-    if (outline) {
-      toc = await addTocItem(pdf, outline, pdfUrl, []);
-    }
+    const tocPromises = outline.map(async (chapter) => {
+      const dest = chapter.dest;
+      if (dest && dest.length > 0) {
+        // get the page referance
+        const ref = dest[0];
+        const pageIndex = await pdf.getPageIndex(ref);
+        if (pageIndex) {
+          const link: ReadiumLink = {
+            title: chapter.title,
+            href: `${pdfUrl}#page=${pageIndex.num + 1}`,
+            children: [],
+          };
+          return link;
+        }
+      }
+      return undefined;
+    });
+    // await all the promises and filter any undefined values (tere was no chapter.dest or pageIndex)
+    const toc = (await Promise.all(tocPromises)).filter(
+      (item): item is ReadiumLink => !!item
+    );
     if (toc.length > 0) {
       manifest.toc = toc;
     }

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -67,8 +67,6 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     settings: undefined,
   });
 
-  console.log(state);
-
   // state we can derive from the state above
   const isFetching = !state.resource;
   const isParsed = typeof state.numPages === 'number';
@@ -169,10 +167,7 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
 
     const isLastResource =
       state.resourceIndex === manifest?.readingOrder?.length - 1;
-    const isResourceEnd =
-      (isLastResource && state.pageNumber === state.numPages) ||
-      // On scroll mode, next page button takes you to the next resource. So we can just hide the next button on last resource.
-      (state.settings.isScrolling && isLastResource);
+    const isResourceEnd = isLastResource && state.pageNumber === state.numPages;
 
     dispatch({
       type: 'BOOK_BOUNDARY_CHANGED',
@@ -203,6 +198,18 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
       addTocToManifest(manifest, proxiedUrl);
     }
   }, [isSinglePDF, manifest, proxyUrl, state.resourceIndex]);
+
+  /**
+   * In scrolling mode, manually scroll the user when the page changes
+   */
+  React.useEffect(() => {
+    if (!state.settings?.isScrolling) return;
+    const page = document.querySelector(
+      `[data-page-number="${state.pageNumber}"]`
+    );
+    if (!page) return;
+    page.scrollIntoView();
+  }, [state.pageNumber, state.settings?.isScrolling]);
 
   const goForward = React.useCallback(async () => {
     dispatch({ type: 'GO_FORWARD' });

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -170,7 +170,6 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
       isLastResource && state.pageNumber === state.numPages;
     const showNextButton = isScrolling ? !isLastResource : !isLastResourceEnd;
 
-    console.log('showNext', showNextButton, isScrolling, isLastResource);
     dispatch({
       type: 'BOOK_BOUNDARY_CHANGED',
       atStart: !showPrevButton,

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -60,6 +60,7 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     atStart: true,
     atEnd: false,
     settings: undefined,
+    rendered: false,
   });
 
   // state we can derive from the state above
@@ -188,12 +189,16 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
    */
   React.useEffect(() => {
     if (!state.settings?.isScrolling) return;
-    const page = document.querySelector(
-      `[data-page-number="${state.pageNumber}"]`
-    );
-    if (!page) return;
-    page.scrollIntoView();
-  }, [state.pageNumber, state.settings?.isScrolling]);
+    // if the resource is not yet loaded, don't do anything yet
+    if (!state.rendered) return;
+
+    process.nextTick(() => {
+      const page = document.querySelector(
+        `[data-page-number="${state.pageNumber}"]`
+      );
+      page?.scrollIntoView();
+    });
+  }, [state.pageNumber, state.settings?.isScrolling, state.rendered]);
 
   const goForward = React.useCallback(async () => {
     dispatch({ type: 'GO_FORWARD' });

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -334,30 +334,21 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
   React.useEffect(() => {
     if (!manifest || state.state !== 'ACTIVE') return;
 
-    // Hide all buttons for single PDF on scroll mode
-    if (isSinglePDF && state.settings.isScrolling) {
-      dispatch({
-        type: 'BOOK_BOUNDARY_CHANGED',
-        atStart: true,
-        atEnd: true,
-      });
-    } else {
-      const isFirstResource = state.resourceIndex === 0;
-      const isResourceStart = isFirstResource && state.pageNumber === 1;
+    const isFirstResource = state.resourceIndex === 0;
+    const isResourceStart = isFirstResource && state.pageNumber === 1;
 
-      const isLastResource =
-        state.resourceIndex === manifest?.readingOrder?.length - 1;
-      const isResourceEnd =
-        (isLastResource && state.pageNumber === state.numPages) ||
-        // On scroll mode, next page button takes you to the next resource. So we can just hide the next button on last resource.
-        (state.settings.isScrolling && isLastResource);
+    const isLastResource =
+      state.resourceIndex === manifest?.readingOrder?.length - 1;
+    const isResourceEnd =
+      (isLastResource && state.pageNumber === state.numPages) ||
+      // On scroll mode, next page button takes you to the next resource. So we can just hide the next button on last resource.
+      (state.settings.isScrolling && isLastResource);
 
-      dispatch({
-        type: 'BOOK_BOUNDARY_CHANGED',
-        atStart: isResourceStart,
-        atEnd: isResourceEnd,
-      });
-    }
+    dispatch({
+      type: 'BOOK_BOUNDARY_CHANGED',
+      atStart: isResourceStart,
+      atEnd: isResourceEnd,
+    });
   }, [
     manifest,
     state.state,

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -374,7 +374,11 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     }
   }, [isSinglePDF, manifest, proxyUrl, state.resourceIndex]);
 
-  // prev and next page functions
+  /**
+   * Next page button. Has to handle:
+   *   - going to the next page in the current resource
+   *   - going to the next resource if at the end of current resource
+   */
   const goForward = React.useCallback(async () => {
     // do nothing if we haven't parsed the number of pages yet
     if (!state.numPages) return;
@@ -416,9 +420,14 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     state.resourceIndex,
   ]);
 
+  /**
+   * Prev page button. Has to handle:
+   *   - Go back one page in current resource
+   *   - Go to the last page of previous resource if at the beginning
+   */
   const goBackward = React.useCallback(async () => {
     // do nothing if we haven't parsed the PDF yet
-    if (!isParsed) return;
+    if (!isParsed || !state.numPages) return;
     // do nothing if the reader is inactive
     if (state.state !== 'ACTIVE') return;
 

--- a/src/PdfReader/lib.ts
+++ b/src/PdfReader/lib.ts
@@ -1,0 +1,96 @@
+import { WebpubManifest } from '../types';
+import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
+
+export const IFRAME_WRAPPER_ID = 'iframe-wrapper';
+export const SCALE_STEP = 0.1;
+export const START_QUERY = 'start';
+
+export const getResourceUrl = (
+  index: number,
+  readingOrder: ReadiumLink[] | undefined
+): string => {
+  if (!readingOrder || !readingOrder.length) {
+    throw new Error('A manifest has been returned, but has no reading order');
+  }
+
+  // If it has no children, return the link href
+  return readingOrder[index].href;
+};
+
+export const loadResource = async (
+  resourceUrl: string,
+  proxyUrl?: string
+): Promise<Uint8Array> => {
+  // Generate the resource URL using the proxy
+  const url: string = proxyUrl
+    ? `${proxyUrl}${encodeURIComponent(resourceUrl)}`
+    : resourceUrl;
+  const response = await fetch(url, { mode: 'cors' });
+  const array = new Uint8Array(await response.arrayBuffer());
+
+  if (!response.ok) {
+    throw new Error('Response not Ok for URL: ' + url);
+  }
+  return array;
+};
+
+/**
+ * Gets the index of the provided href in the readingOrder, or throws an error if one
+ * is not found.
+ */
+export function getIndexFromHref(
+  href: string,
+  manifest: WebpubManifest
+): number {
+  const input = new URL(href);
+  const index = manifest?.readingOrder?.findIndex((link) => {
+    return doHrefsMatch(link.href, input);
+  });
+  if (index < 0) {
+    throw new Error(`Cannot find resource in readingOrder: ${href}`);
+  }
+  return index;
+}
+
+/**
+ * Compares two hrefs without query params or hash
+ */
+export function doHrefsMatch(
+  href1: string | URL,
+  href2: string | URL
+): boolean {
+  const input1 = new URL(href1);
+  const input2 = new URL(href2);
+  return (
+    input1.pathname === input2.pathname &&
+    input1.hostname === input2.hostname &&
+    input1.protocol === input2.protocol
+  );
+}
+
+/**
+ * Extracts a start page from a href if it exists and is in the format
+ * `?startPage=1`. Returns undefined if none found.
+ */
+export const getStartPageFromHref = (href: string): number | undefined => {
+  const params = new URL(href).searchParams;
+  const startPage = params.get(START_QUERY);
+  return startPage ? parseInt(startPage) : undefined;
+};
+
+/**
+ * Extracts a page number from a href if it exists and is in
+ * the format of `#page=1`
+ */
+export const getPageNumberFromHref = (href: string): number | undefined => {
+  const hash = new URL(href).hash;
+  try {
+    const strPageNumber = hash.replace('#page=', '');
+    if (!strPageNumber || strPageNumber === 'NaN') return undefined;
+    const pageNumber = parseInt(strPageNumber);
+    return pageNumber;
+  } catch (e) {
+    console.warn(`Failed to parse page number from hash ${hash}`);
+    return undefined;
+  }
+};

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -1,106 +1,198 @@
 import { DEFAULT_SETTINGS } from '../constants';
+import { ReaderArguments } from '../types';
+import {
+  getIndexFromHref,
+  getStartPageFromHref,
+  getPageNumberFromHref,
+} from './lib';
 import { PdfState, PdfReaderAction } from './types';
 
-export function pdfReducer(state: PdfState, action: PdfReaderAction): PdfState {
-  console.log('action', action);
-  switch (action.type) {
-    case 'ARGS_CHANGED': {
-      return {
-        state: 'ACTIVE',
-        settings: DEFAULT_SETTINGS,
-        resourceIndex: 0,
-        resource: null,
-        pageNumber: 1,
-        numPages: null,
-        scale: 1,
-        pdfWidth: 0,
-        pdfHeight: 0,
-        pageHeight: undefined,
-        pageWidth: undefined,
-        atStart: true,
-        atEnd: false,
-      };
+/**
+ * TODO:
+ *
+ * - handle #startPage in goForward and goBackward
+ * - handle #page in goForward and goBackward
+ */
+
+export function makePdfReducer(
+  args: ReaderArguments
+): (state: PdfState, action: PdfReaderAction) => PdfState {
+  /**
+   * If there are no args, it's an inactive hook, or you are pre-first render.
+   * just use a function that returns the state in most cases so you don't have
+   * to keep checking if args is defined.
+   */
+  if (!args) return (state: PdfState, _action: PdfReaderAction) => state;
+
+  return function reducer(state: PdfState, action: PdfReaderAction): PdfState {
+    if (state.state !== 'ACTIVE' && action.type !== 'ARGS_CHANGED') {
+      return handleInvalidTransition(state, action);
     }
-    /**
-     * Cleares the current resource and sets the current index, which will cause
-     * the useEffect hook to load a new resource.
-     */
-    case 'SET_CURRENT_RESOURCE':
-      if (state.resourceIndex === action.index) return state;
-      return {
-        ...state,
-        resource: null,
-        resourceIndex: action.index,
-        pageNumber: action.shouldNavigateToEnd ? -1 : 1,
-        numPages: null,
-      };
 
-    case 'RESOURCE_FETCH_SUCCESS':
-      return {
-        ...state,
-        resource: action.resource,
-      };
-
-    // called when the resource has been parsed by react-pdf
-    // and we know the number of pages
-    case 'PDF_PARSED':
-      return {
-        ...state,
-        numPages: action.numPages,
-        // if the state.pageNumber is -1, we know to navigate to the
-        // end of the PDF that was just parsed
-        pageNumber:
-          state.pageNumber === -1 ? action.numPages : state.pageNumber,
-      };
-
-    // Navigates to page in resource
-    case 'NAVIGATE_PAGE':
-      return {
-        ...state,
-        pageNumber: action.pageNum,
-      };
-
-    case 'SET_SCROLL':
-      if (state.state !== 'ACTIVE') {
-        return handleInvalidTransition(state, action);
+    function goToLocation(index: number, page = 1): PdfState {
+      // only set the resource to null if you're actually changing resources (not just
+      // navigating to a different page in the same resource)
+      const shouldResetResource = state.resourceIndex !== index;
+      const newState = { ...state, resourceIndex: index, pageNumber: page };
+      if (shouldResetResource) {
+        return {
+          ...newState,
+          resource: null,
+          numPages: null,
+        };
       }
-      return {
-        ...state,
-        settings: {
-          ...state.settings,
-          isScrolling: action.isScrolling,
-        },
-      };
+      return newState;
+    }
 
-    case 'SET_SCALE':
-      return {
-        ...state,
-        scale: action.scale,
-      };
+    switch (action.type) {
+      case 'ARGS_CHANGED': {
+        return {
+          state: 'ACTIVE',
+          settings: DEFAULT_SETTINGS,
+          resourceIndex: 0,
+          resource: null,
+          pageNumber: 1,
+          numPages: null,
+          scale: 1,
+          pdfWidth: 0,
+          pdfHeight: 0,
+          pageHeight: undefined,
+          pageWidth: undefined,
+          atStart: true,
+          atEnd: false,
+        };
+      }
+      /**
+       * Cleares the current resource and sets the current index, which will cause
+       * the useEffect hook to load a new resource.
+       */
+      case 'SET_CURRENT_RESOURCE':
+        if (state.resourceIndex === action.index) return state;
+        return {
+          ...state,
+          resource: null,
+          resourceIndex: action.index,
+          pageNumber: action.shouldNavigateToEnd ? -1 : 1,
+          numPages: null,
+        };
 
-    case 'PAGE_LOAD_SUCCESS':
-      return {
-        ...state,
-        pdfWidth: action.width,
-        pdfHeight: action.height,
-        pageWidth: action.width,
-        pageHeight: action.height,
-      };
+      case 'GO_FORWARD': {
+        /**
+         * Navigate forward one page or one resource if at the end of the current
+         * resource. Do nothing at the end of the last resource.
+         */
+        // do nothing if we have not parsed the number of pages yet.
+        if (!state.numPages) return state;
+        const atEndOfResource = state.pageNumber === state.numPages;
+        const atEndOfBook =
+          state.resourceIndex === args.manifest.readingOrder.length - 1;
 
-    case 'RESIZE_PAGE':
-      return {
-        ...state,
-        pageWidth: action.width,
-        pageHeight: action.height,
-      };
+        if (atEndOfResource) {
+          if (atEndOfBook) return state;
+          // go to next resource
+          return goToLocation(state.resourceIndex + 1);
+        }
+        // go to next page
+        return goToLocation(state.resourceIndex, state.pageNumber + 1);
+      }
 
-    case 'BOOK_BOUNDARY_CHANGED':
-      return {
-        ...state,
-        atStart: action.atStart,
-        atEnd: action.atEnd,
-      };
-  }
+      case 'GO_BACKWARD': {
+        /**
+         * Navigate backward one page or to the end of the previous resource
+         * if at the beginning of the current resource. Do nothing at the
+         * beginning of the first resource.
+         */
+        // do nothing if we have not parsed the number of pages yet.
+        if (!state.numPages) return state;
+        const atStartOfResource = state.pageNumber === 1;
+        const atStartOfBook = state.resourceIndex === 0;
+        if (atStartOfResource) {
+          if (atStartOfBook) return state;
+          // go to end of prev resource
+          return {
+            ...goToLocation(state.resourceIndex - 1, -1),
+          };
+        }
+        // go to prev page
+        return goToLocation(state.resourceIndex, state.pageNumber - 1);
+      }
+
+      case 'GO_TO_HREF': {
+        const resourceIndex = getIndexFromHref(action.href, args.manifest);
+        const startPage = getStartPageFromHref(action.href);
+        const pageNumber = getPageNumberFromHref(action.href);
+
+        const page = pageNumber ?? startPage ?? 1;
+        return goToLocation(resourceIndex, page);
+      }
+
+      case 'RESOURCE_FETCH_SUCCESS':
+        return {
+          ...state,
+          resource: action.resource,
+        };
+
+      // called when the resource has been parsed by react-pdf
+      // and we know the number of pages
+      case 'PDF_PARSED':
+        return {
+          ...state,
+          numPages: action.numPages,
+          // if the state.pageNumber is -1, we know to navigate to the
+          // end of the PDF that was just parsed
+          pageNumber:
+            state.pageNumber === -1 ? action.numPages : state.pageNumber,
+        };
+
+      // Navigates to page in resource
+      case 'NAVIGATE_PAGE':
+        return {
+          ...state,
+          pageNumber: action.pageNum,
+        };
+
+      case 'SET_SCROLL':
+        if (state.state !== 'ACTIVE') {
+          return handleInvalidTransition(state, action);
+        }
+        return {
+          ...state,
+          settings: {
+            ...state.settings,
+            isScrolling: action.isScrolling,
+          },
+        };
+
+      case 'SET_SCALE':
+        return {
+          ...state,
+          scale: action.scale,
+        };
+
+      case 'PAGE_LOAD_SUCCESS':
+        return {
+          ...state,
+          pdfWidth: action.width,
+          pdfHeight: action.height,
+          pageWidth: action.width,
+          pageHeight: action.height,
+        };
+
+      case 'RESIZE_PAGE':
+        return {
+          ...state,
+          pageWidth: action.width,
+          pageHeight: action.height,
+        };
+
+      case 'BOOK_BOUNDARY_CHANGED':
+        return {
+          ...state,
+          atStart: action.atStart,
+          atEnd: action.atEnd,
+        };
+    }
+  };
 }
 
 function handleInvalidTransition(state: PdfState, action: PdfReaderAction) {

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -32,7 +32,7 @@ export function makePdfReducer(
       // navigating to a different page in the same resource)
       const shouldResetResource = state.resourceIndex !== index;
 
-      // check if there is a #startPage in the href of the resource we are navigating to
+      // check if there is a `?startPage` in the href of the resource we are navigating to
       const href = manifest.readingOrder[index].href;
       const startPage = getStartPageFromHref(href);
       // only go to the start page if we don't have another valid page we are navigating to
@@ -104,7 +104,11 @@ export function makePdfReducer(
          */
         // do nothing if we have not parsed the number of pages yet.
         if (!state.numPages) return state;
-        const atStartOfResource = state.pageNumber === 1;
+        const atStartOfResource = isStartOfResource(
+          state.pageNumber,
+          args.manifest.readingOrder[state.resourceIndex].href
+        );
+
         const atStartOfBook = state.resourceIndex === 0;
         if (atStartOfResource) {
           if (atStartOfBook) return state;
@@ -193,4 +197,13 @@ function handleInvalidTransition(state: PdfState, action: PdfReaderAction) {
     `Inavlid state transition attempted: ${state} with ${action.type}`
   );
   return state;
+}
+
+/**
+ * Checks if we are at the start of the resource, taking into account the `?startPage`
+ * query param.
+ */
+function isStartOfResource(pageNumber: number, resourceHref: string) {
+  const startPage = getStartPageFromHref(resourceHref);
+  return pageNumber === (startPage ?? 1);
 }

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_SETTINGS } from '../constants';
+import { PdfState, PdfReaderAction } from './types';
+
+export function pdfReducer(state: PdfState, action: PdfReaderAction): PdfState {
+  console.log('action', action);
+  switch (action.type) {
+    case 'ARGS_CHANGED': {
+      return {
+        state: 'ACTIVE',
+        settings: DEFAULT_SETTINGS,
+        resourceIndex: 0,
+        resource: null,
+        pageNumber: 1,
+        numPages: null,
+        scale: 1,
+        pdfWidth: 0,
+        pdfHeight: 0,
+        pageHeight: undefined,
+        pageWidth: undefined,
+        atStart: true,
+        atEnd: false,
+      };
+    }
+    /**
+     * Cleares the current resource and sets the current index, which will cause
+     * the useEffect hook to load a new resource.
+     */
+    case 'SET_CURRENT_RESOURCE':
+      if (state.resourceIndex === action.index) return state;
+      return {
+        ...state,
+        resource: null,
+        resourceIndex: action.index,
+        pageNumber: action.shouldNavigateToEnd ? -1 : 1,
+        numPages: null,
+      };
+
+    case 'RESOURCE_FETCH_SUCCESS':
+      return {
+        ...state,
+        resource: action.resource,
+      };
+
+    // called when the resource has been parsed by react-pdf
+    // and we know the number of pages
+    case 'PDF_PARSED':
+      return {
+        ...state,
+        numPages: action.numPages,
+        // if the state.pageNumber is -1, we know to navigate to the
+        // end of the PDF that was just parsed
+        pageNumber:
+          state.pageNumber === -1 ? action.numPages : state.pageNumber,
+      };
+
+    // Navigates to page in resource
+    case 'NAVIGATE_PAGE':
+      return {
+        ...state,
+        pageNumber: action.pageNum,
+      };
+
+    case 'SET_SCROLL':
+      if (state.state !== 'ACTIVE') {
+        return handleInvalidTransition(state, action);
+      }
+      return {
+        ...state,
+        settings: {
+          ...state.settings,
+          isScrolling: action.isScrolling,
+        },
+      };
+
+    case 'SET_SCALE':
+      return {
+        ...state,
+        scale: action.scale,
+      };
+
+    case 'PAGE_LOAD_SUCCESS':
+      return {
+        ...state,
+        pdfWidth: action.width,
+        pdfHeight: action.height,
+        pageWidth: action.width,
+        pageHeight: action.height,
+      };
+
+    case 'RESIZE_PAGE':
+      return {
+        ...state,
+        pageWidth: action.width,
+        pageHeight: action.height,
+      };
+
+    case 'BOOK_BOUNDARY_CHANGED':
+      return {
+        ...state,
+        atStart: action.atStart,
+        atEnd: action.atEnd,
+      };
+  }
+}
+
+function handleInvalidTransition(state: PdfState, action: PdfReaderAction) {
+  console.trace(
+    `Inavlid state transition attempted: ${state} with ${action.type}`
+  );
+  return state;
+}

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -29,6 +29,10 @@ export function makePdfReducer(
       return handleInvalidTransition(state, action);
     }
 
+    /**
+     * Utility function to generate state navigating us to a given resource and page.
+     * Used by multiple cases below.
+     */
     function goToLocation(index: number, page = 1): PdfState {
       // only set the resource to null if you're actually changing resources (not just
       // navigating to a different page in the same resource)
@@ -62,19 +66,6 @@ export function makePdfReducer(
           atEnd: false,
         };
       }
-      /**
-       * Cleares the current resource and sets the current index, which will cause
-       * the useEffect hook to load a new resource.
-       */
-      case 'SET_CURRENT_RESOURCE':
-        if (state.resourceIndex === action.index) return state;
-        return {
-          ...state,
-          resource: null,
-          resourceIndex: action.index,
-          pageNumber: action.shouldNavigateToEnd ? -1 : 1,
-          numPages: null,
-        };
 
       case 'GO_FORWARD': {
         /**
@@ -142,13 +133,6 @@ export function makePdfReducer(
           // end of the PDF that was just parsed
           pageNumber:
             state.pageNumber === -1 ? action.numPages : state.pageNumber,
-        };
-
-      // Navigates to page in resource
-      case 'NAVIGATE_PAGE':
-        return {
-          ...state,
-          pageNumber: action.pageNum,
         };
 
       case 'SET_SCROLL':

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -52,6 +52,11 @@ export function makePdfReducer(
           ...newState,
           resource: null,
           numPages: null,
+          rendered: false,
+          pageHeight: undefined,
+          pageWidth: undefined,
+          pdfHeight: 0,
+          pdfWidth: 0,
         };
       }
       return newState;
@@ -73,10 +78,20 @@ export function makePdfReducer(
           pageWidth: undefined,
           atStart: true,
           atEnd: false,
+          rendered: false,
         };
       }
 
       case 'GO_FORWARD': {
+        /**
+         * In scrolling mode, we simply move forward one whole resource
+         */
+        if (state.settings?.isScrolling) {
+          const atEndOfBook =
+            state.resourceIndex === args.manifest.readingOrder.length - 1;
+          if (atEndOfBook) return state;
+          return goToLocation(state.resourceIndex + 1);
+        }
         /**
          * Navigate forward one page or one resource if at the end of the current
          * resource. Do nothing at the end of the last resource.
@@ -97,6 +112,14 @@ export function makePdfReducer(
       }
 
       case 'GO_BACKWARD': {
+        /**
+         * In scrolling mode, we simply move forward one whole resource
+         */
+        if (state.settings?.isScrolling) {
+          const atStartOfBook = state.resourceIndex === 0;
+          if (atStartOfBook) return state;
+          return goToLocation(state.resourceIndex - 1);
+        }
         /**
          * Navigate backward one page or to the end of the previous resource
          * if at the beginning of the current resource. Do nothing at the
@@ -169,6 +192,7 @@ export function makePdfReducer(
       case 'PAGE_LOAD_SUCCESS':
         return {
           ...state,
+          rendered: true,
           pdfWidth: action.width,
           pdfHeight: action.height,
           pageWidth: action.width,

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -1,0 +1,47 @@
+import { ReaderArguments, ReaderSettings, ReaderState } from '../types';
+
+export type InternalState = {
+  resourceIndex: number;
+  resource: { data: Uint8Array } | null;
+  // we only know the numPages once the resource has been parsed
+  numPages: number | null;
+  // if pageNumber is -1, we will navigate to the end of the
+  // resource once it is parsed
+  pageNumber: number;
+  scale: number;
+  pdfHeight: number;
+  pdfWidth: number;
+  pageHeight: number | undefined;
+  pageWidth: number | undefined;
+};
+
+export type InactiveState = ReaderState &
+  InternalState & { state: 'INACTIVE'; settings: undefined };
+
+export type ActiveState = ReaderState &
+  InternalState & { state: 'ACTIVE'; settings: ReaderSettings };
+
+export type PdfState = InactiveState | ActiveState;
+
+export type PdfReaderAction =
+  | {
+      type: 'ARGS_CHANGED';
+      args: ReaderArguments;
+    }
+  | {
+      type: 'SET_CURRENT_RESOURCE';
+      index: number;
+      shouldNavigateToEnd: boolean;
+    }
+  | { type: 'RESOURCE_FETCH_SUCCESS'; resource: { data: Uint8Array } }
+  | { type: 'PDF_PARSED'; numPages: number }
+  | { type: 'NAVIGATE_PAGE'; pageNum: number }
+  | { type: 'SET_SCALE'; scale: number }
+  | { type: 'SET_SCROLL'; isScrolling: boolean }
+  | { type: 'PAGE_LOAD_SUCCESS'; height: number; width: number }
+  | {
+      type: 'RESIZE_PAGE';
+      height: number | undefined;
+      width: number | undefined;
+    }
+  | { type: 'BOOK_BOUNDARY_CHANGED'; atStart: boolean; atEnd: boolean };

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -13,6 +13,7 @@ export type InternalState = {
   pdfWidth: number;
   pageHeight: number | undefined;
   pageWidth: number | undefined;
+  rendered: boolean;
 };
 
 export type InactiveState = ReaderState &

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -28,17 +28,11 @@ export type PdfReaderAction =
       type: 'ARGS_CHANGED';
       args: ReaderArguments;
     }
-  | {
-      type: 'SET_CURRENT_RESOURCE';
-      index: number;
-      shouldNavigateToEnd: boolean;
-    }
   | { type: 'GO_FORWARD' }
   | { type: 'GO_BACKWARD' }
   | { type: 'GO_TO_HREF'; href: string }
   | { type: 'RESOURCE_FETCH_SUCCESS'; resource: { data: Uint8Array } }
   | { type: 'PDF_PARSED'; numPages: number }
-  | { type: 'NAVIGATE_PAGE'; pageNum: number }
   | { type: 'SET_SCALE'; scale: number }
   | { type: 'SET_SCROLL'; isScrolling: boolean }
   | { type: 'PAGE_LOAD_SUCCESS'; height: number; width: number }

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -33,6 +33,9 @@ export type PdfReaderAction =
       index: number;
       shouldNavigateToEnd: boolean;
     }
+  | { type: 'GO_FORWARD' }
+  | { type: 'GO_BACKWARD' }
+  | { type: 'GO_TO_HREF'; href: string }
   | { type: 'RESOURCE_FETCH_SUCCESS'; resource: { data: Uint8Array } }
   | { type: 'PDF_PARSED'; numPages: number }
   | { type: 'NAVIGATE_PAGE'; pageNum: number }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,3 +49,4 @@ export { getTheme } from './ui/theme';
 export { default as useColorModeValue } from './ui/hooks/useColorModeValue';
 export * from './constants';
 export { clearWebReaderLocalStorage } from './utils/localstorage';
+export { default as addTocToManifest } from './PdfReader/addTocToManifest';


### PR DESCRIPTION
This PR:

1. Extracts the reducer, types, and utility functions into separate files for easier understanding
2. Makes a `GO_FORWARD` `GO_BACKWARD` and `GO_TO_HREF` action.
3. Moves all action logic into the reducer (out of the callback) so it can be shared easier and centralized.
4. Makes an effect that scrolls the user to the correct page when the page number chanages. 
5. Updates `addTocToManifest` to avoid passing a mutable `toc` value to a separate function.

There is one more thing I would like to try, which is adding the toc to the manifest outside of the web reader. I will have to give this a go tomorrow 