### PR TITLE
NO-REF: Add export for type and fix warnings

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,7 +1,7 @@
 import 'react-app-polyfill/ie11';
 import 'regenerator-runtime/runtime';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import {
   BrowserRouter,
   Switch,
@@ -463,4 +463,6 @@ const DynamicReader: React.FC = () => {
   );
 };
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root') as HTMLElement;
+const root = createRoot(container);
+root.render(<App />);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,3 +50,4 @@ export { default as useColorModeValue } from './ui/hooks/useColorModeValue';
 export * from './constants';
 export { clearWebReaderLocalStorage } from './utils/localstorage';
 export { default as addTocToManifest } from './PdfReader/addTocToManifest';
+export type { WebpubManifest } from './WebpubManifestTypes/WebpubManifest';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,4 +50,5 @@ export { default as useColorModeValue } from './ui/hooks/useColorModeValue';
 export * from './constants';
 export { clearWebReaderLocalStorage } from './utils/localstorage';
 export { default as addTocToManifest } from './PdfReader/addTocToManifest';
+export type { ReadiumLink } from './WebpubManifestTypes/ReadiumLink';
 export type { WebpubManifest } from './WebpubManifestTypes/WebpubManifest';

--- a/src/ui/ToggleButton.tsx
+++ b/src/ui/ToggleButton.tsx
@@ -21,16 +21,26 @@ export type ToggleButtonProps = React.ComponentPropsWithoutRef<
   iconFill?: string;
   label?: string;
   value: string;
+  isChecked: boolean;
 };
 
 function ToggleButton(
   props: React.PropsWithoutRef<ToggleButtonProps>
 ): React.ReactElement {
-  const { children, colorMode, icon, iconFill, label, value, ...rest } = props;
-  const { getInputProps, getCheckboxProps } = useRadio(props);
+  const {
+    children,
+    colorMode,
+    icon,
+    iconFill,
+    label,
+    value,
+    isChecked,
+    ...rest
+  } = props;
+  const { getInputProps, getRadioProps } = useRadio(props);
 
   const input = getInputProps();
-  const checkbox = getCheckboxProps();
+  const radio = getRadioProps();
   const theme = useTheme();
 
   return (
@@ -39,13 +49,7 @@ function ToggleButton(
       <Fonts />
       <ChakraBox as="label" display="flex" flexGrow={1} aria-label={label}>
         <input {...input} />
-        <Button
-          as="div"
-          variant="settings"
-          flexGrow={1}
-          {...checkbox}
-          {...rest}
-        >
+        <Button as="div" variant="settings" flexGrow={1} {...radio} {...rest}>
           {icon && (
             <Icon
               as={icon}

--- a/src/ui/menu/use-menu.tsx
+++ b/src/ui/menu/use-menu.tsx
@@ -758,7 +758,6 @@ export function useMenuOptionGroup(props: UseMenuOptionGroupProps = {}) {
       isChecked,
     });
   });
-
   return {
     ...htmlProps,
     children: clones,

--- a/src/ui/nypl-base-theme/foundations/breakpoints.ts
+++ b/src/ui/nypl-base-theme/foundations/breakpoints.ts
@@ -1,10 +1,10 @@
 // theme.js
-import { createBreakpoints } from '@chakra-ui/theme-tools';
-
-export default createBreakpoints({
+const breakpoints = {
   sm: '20em', // 320px
   md: '38em', // 600px
   lg: '60em', // 960px
   xl: '80em', // 1280px
   '2xl': '96em',
-});
+};
+
+export default breakpoints;

--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -10,7 +10,7 @@ describe('Header Accessibility checker', () => {
     const { container } = render(<Header {...MockHtmlReaderProps} />);
 
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 15000);
 });
 
 describe('Header rendering', () => {

--- a/tests/SettingsCard.test.tsx
+++ b/tests/SettingsCard.test.tsx
@@ -23,7 +23,7 @@ describe('SettingsCard Accessibility checker', () => {
     );
 
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 15000);
 });
 
 describe('Render settings for different media type', () => {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,4 +1,2 @@
 import '@testing-library/jest-dom';
 import 'jest-axe/extend-expect';
-
-jest.setTimeout(15000);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,2 +1,4 @@
 import '@testing-library/jest-dom';
 import 'jest-axe/extend-expect';
+
+jest.setTimeout(15000);


### PR DESCRIPTION
- Add export for ReadiumLink and WebpubManifest types to be used in consuming apps
- Fix warnings from browser for deprecated functions