### PR TITLE
SFR-1944: Add error state for PDFReader

### DIFF
--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -244,7 +244,7 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     };
   }
 
-  if (state.state === 'ERROR') throw state.loadError;
+  if (state.state === 'ERROR') throw state.error;
 
   // if (isFetching) {
   //   // The Reader is fetching a PDF resource

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -244,6 +244,8 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     };
   }
 
+  if (state.state === 'ERROR') throw state.loadError;
+
   // if (isFetching) {
   //   // The Reader is fetching a PDF resource
   //   return {
@@ -280,6 +282,13 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
     dispatch({
       type: 'PDF_PARSED',
       numPages: numPages,
+    });
+  };
+
+  const onDocumentLoadError = (error: Error) => {
+    dispatch({
+      type: 'PDF_LOAD_ERROR',
+      error: error,
     });
   };
 
@@ -331,7 +340,11 @@ export default function usePdfReader(args: ReaderArguments): ReaderReturn {
             }
           `}
         </style>
-        <Document file={state.resource} onLoadSuccess={onDocumentLoadSuccess}>
+        <Document
+          file={state.resource}
+          onLoadSuccess={onDocumentLoadSuccess}
+          onLoadError={onDocumentLoadError}
+        >
           {isParsed && state.numPages && (
             <>
               {state.settings.isScrolling &&

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -171,6 +171,14 @@ export function makePdfReducer(
             state.pageNumber === -1 ? action.numPages : state.pageNumber,
         };
 
+      case 'PDF_LOAD_ERROR':
+        return {
+          ...state,
+          state: 'ERROR',
+          loadError: action.error,
+          settings: DEFAULT_SETTINGS,
+        };
+
       case 'SET_SCROLL':
         if (state.state !== 'ACTIVE') {
           return handleInvalidTransition(state, action);

--- a/src/PdfReader/reducer.ts
+++ b/src/PdfReader/reducer.ts
@@ -175,7 +175,7 @@ export function makePdfReducer(
         return {
           ...state,
           state: 'ERROR',
-          loadError: action.error,
+          error: action.error,
           settings: DEFAULT_SETTINGS,
         };
 

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -22,7 +22,14 @@ export type InactiveState = ReaderState &
 export type ActiveState = ReaderState &
   InternalState & { state: 'ACTIVE'; settings: ReaderSettings };
 
-export type PdfState = InactiveState | ActiveState;
+export type ErrorState = ReaderState &
+  InternalState & {
+    state: 'ERROR';
+    loadError: Error;
+    settings: ReaderSettings;
+  };
+
+export type PdfState = InactiveState | ActiveState | ErrorState;
 
 export type PdfReaderAction =
   | {
@@ -34,6 +41,7 @@ export type PdfReaderAction =
   | { type: 'GO_TO_HREF'; href: string }
   | { type: 'RESOURCE_FETCH_SUCCESS'; resource: { data: Uint8Array } }
   | { type: 'PDF_PARSED'; numPages: number }
+  | { type: 'PDF_LOAD_ERROR'; error: Error }
   | { type: 'SET_SCALE'; scale: number }
   | { type: 'SET_SCROLL'; isScrolling: boolean }
   | { type: 'PAGE_LOAD_SUCCESS'; height: number; width: number }

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -25,7 +25,7 @@ export type ActiveState = ReaderState &
 export type ErrorState = ReaderState &
   InternalState & {
     state: 'ERROR';
-    loadError: Error;
+    error: Error;
     settings: ReaderSettings;
   };
 


### PR DESCRIPTION
Adds an error state for the PDFReader. The error state is set if the document fails to load and throws the error when updated.