### PR TITLE
NOREF: Format files, update linting, fix PDF reader page bug

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,3 +23,7 @@ example/static/**/*
 
 # the cors-proxy
 example/cors-proxy.js
+
+# Playwright tests
+playwright
+playwright-report

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "source.organizeImports": "explicit",
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.lintTask.options": "-c ./web/.eslintrc.json --ignore-path ./web/.eslintignore .",
+  "eslint.lintTask.options": "-c ./.eslintrc.js --ignore-path ./.eslintignore .",
   "eslint.validate": [
     "javascript",
     "javascriptreact",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,42 @@
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.lintTask.options": "-c ./web/.eslintrc.json --ignore-path ./web/.eslintignore .",
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "[json]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "parcel": "2.16.3",
         "parcel-config-precache-manifest": "0.0.4",
         "parcel-reporter-static-files-copy": "1.5.3",
-        "prettier": "2.2.1",
+        "prettier": "3.8.1",
         "process": "0.11.10",
         "react": "18.2.0",
         "react-app-polyfill": "2.0.0",
@@ -6142,9 +6142,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.58.0.tgz",
-      "integrity": "sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -6156,9 +6156,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.58.0.tgz",
-      "integrity": "sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -6170,9 +6170,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.58.0.tgz",
-      "integrity": "sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -6184,9 +6184,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.58.0.tgz",
-      "integrity": "sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -6198,9 +6198,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.58.0.tgz",
-      "integrity": "sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -6212,9 +6212,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.58.0.tgz",
-      "integrity": "sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -6226,9 +6226,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.58.0.tgz",
-      "integrity": "sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -6240,9 +6240,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.58.0.tgz",
-      "integrity": "sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -6254,9 +6254,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.58.0.tgz",
-      "integrity": "sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -6268,9 +6268,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.58.0.tgz",
-      "integrity": "sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -6282,9 +6282,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.58.0.tgz",
-      "integrity": "sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -6296,9 +6296,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.58.0.tgz",
-      "integrity": "sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -6310,9 +6310,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.58.0.tgz",
-      "integrity": "sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -6324,9 +6324,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.58.0.tgz",
-      "integrity": "sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -6338,9 +6338,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.58.0.tgz",
-      "integrity": "sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -6352,9 +6352,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.58.0.tgz",
-      "integrity": "sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -6366,9 +6366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.58.0.tgz",
-      "integrity": "sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -6380,9 +6380,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -6394,9 +6394,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
-      "integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -6408,9 +6408,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.58.0.tgz",
-      "integrity": "sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -6422,9 +6422,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.58.0.tgz",
-      "integrity": "sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -6436,9 +6436,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.58.0.tgz",
-      "integrity": "sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -6450,9 +6450,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.58.0.tgz",
-      "integrity": "sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -6464,9 +6464,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -6478,9 +6478,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.58.0.tgz",
-      "integrity": "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -8226,9 +8226,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15193,9 +15193,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16658,16 +16658,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -17632,9 +17635,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
-      "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17648,31 +17651,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.58.0",
-        "@rollup/rollup-android-arm64": "4.58.0",
-        "@rollup/rollup-darwin-arm64": "4.58.0",
-        "@rollup/rollup-darwin-x64": "4.58.0",
-        "@rollup/rollup-freebsd-arm64": "4.58.0",
-        "@rollup/rollup-freebsd-x64": "4.58.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.58.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.58.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.58.0",
-        "@rollup/rollup-linux-arm64-musl": "4.58.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.58.0",
-        "@rollup/rollup-linux-loong64-musl": "4.58.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.58.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.58.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.58.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.58.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-musl": "4.58.0",
-        "@rollup/rollup-openbsd-x64": "4.58.0",
-        "@rollup/rollup-openharmony-arm64": "4.58.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.58.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.58.0",
-        "@rollup/rollup-win32-x64-gnu": "4.58.0",
-        "@rollup/rollup-win32-x64-msvc": "4.58.0",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "parcel": "2.16.3",
     "parcel-config-precache-manifest": "0.0.4",
     "parcel-reporter-static-files-copy": "1.5.3",
-    "prettier": "2.2.1",
+    "prettier": "3.8.1",
     "process": "0.11.10",
     "react": "18.2.0",
     "react-app-polyfill": "2.0.0",

--- a/playwright/pageobjects/web-reader.page.ts
+++ b/playwright/pageobjects/web-reader.page.ts
@@ -191,22 +191,7 @@ class PdfReaderPage extends WebReaderPage {
     await this.page.goto(gotoPage, { waitUntil: 'domcontentloaded' });
     await this.loadPage();
     await expect(this.pageOne).toBeVisible();
-    await this.ensureOnFirstPage();
     return new WebReaderPage(this.page);
-  }
-
-  async ensureOnFirstPage(): Promise<void> {
-    await expect(this.pageInput).toBeVisible();
-    const currentPage = await this.pageInput.inputValue();
-
-    if (currentPage !== '1') {
-      await this.pageInput.fill('1');
-      await this.pageInput.press('Enter');
-      await this.loadPage();
-    }
-
-    await expect(this.pageInput).toHaveValue('1');
-    await expect(this.previousPageButton).toBeDisabled();
   }
 
   async loadPage(): Promise<void> {
@@ -255,7 +240,6 @@ class PdfReaderPage extends WebReaderPage {
   }
 
   async navigateReader(): Promise<void> {
-    await this.ensureOnFirstPage();
     await expect(this.nextPageButton).toBeVisible();
     await expect(this.nextPageButton).toBeEnabled();
     await expect(this.previousPageButton).toBeVisible();

--- a/playwright/pageobjects/web-reader.page.ts
+++ b/playwright/pageobjects/web-reader.page.ts
@@ -191,7 +191,22 @@ class PdfReaderPage extends WebReaderPage {
     await this.page.goto(gotoPage, { waitUntil: 'domcontentloaded' });
     await this.loadPage();
     await expect(this.pageOne).toBeVisible();
+    await this.ensureOnFirstPage();
     return new WebReaderPage(this.page);
+  }
+
+  async ensureOnFirstPage(): Promise<void> {
+    await expect(this.pageInput).toBeVisible();
+    const currentPage = await this.pageInput.inputValue();
+
+    if (currentPage !== '1') {
+      await this.pageInput.fill('1');
+      await this.pageInput.press('Enter');
+      await this.loadPage();
+    }
+
+    await expect(this.pageInput).toHaveValue('1');
+    await expect(this.previousPageButton).toBeDisabled();
   }
 
   async loadPage(): Promise<void> {
@@ -240,6 +255,7 @@ class PdfReaderPage extends WebReaderPage {
   }
 
   async navigateReader(): Promise<void> {
+    await this.ensureOnFirstPage();
     await expect(this.nextPageButton).toBeVisible();
     await expect(this.nextPageButton).toBeEnabled();
     await expect(this.previousPageButton).toBeVisible();

--- a/src/HtmlReader/ReadiumCss/ReadiumCSS-after.css
+++ b/src/HtmlReader/ReadiumCss/ReadiumCSS-after.css
@@ -637,14 +637,16 @@ body {
 
 :root[style*='readium-font-on'][style*='AccessibleDfA'] {
   /* We won’t use the variable there since we need fallbacks for missing characters */
-  font-family: AccessibleDfA, Verdana, Tahoma, 'Trebuchet MS', sans-serif !important;
+  font-family:
+    AccessibleDfA, Verdana, Tahoma, 'Trebuchet MS', sans-serif !important;
   --RS__lineHeightCompensation: 1.167;
 }
 
 :root[style*='readium-font-on'][style*='IA Writer Duospace'] {
   /* We won’t use the variable there since we need fallbacks for missing characters */
-  font-family: 'IA Writer Duospace', Menlo, 'DejaVu Sans Mono',
-    'Bitstream Vera Sans Mono', Courier, monospace !important;
+  font-family:
+    'IA Writer Duospace', Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono',
+    Courier, monospace !important;
   --RS__lineHeightCompensation: 1.167;
 }
 

--- a/src/HtmlReader/ReadiumCss/ReadiumCSS-before.css
+++ b/src/HtmlReader/ReadiumCss/ReadiumCSS-before.css
@@ -68,10 +68,11 @@
 
 :root {
   /* Default font-stacks */
-  --RS__oldStyleTf: 'Iowan Old Style', 'Sitka Text', Palatino, 'Book Antiqua',
-    serif;
+  --RS__oldStyleTf:
+    'Iowan Old Style', 'Sitka Text', Palatino, 'Book Antiqua', serif;
   --RS__modernTf: Athelas, Constantia, Georgia, serif;
-  --RS__sansTf: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto,
+  --RS__sansTf:
+    -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, sans-serif;
   --RS__humanistTf: Seravek, Calibri, Roboto, Arial, sans-serif;
   --RS__monospaceTf: 'Andale Mono', Consolas, monospace;
@@ -119,7 +120,8 @@ h3 {
 /* Set default font for Math */
 
 math {
-  font-family: 'Latin Modern Math', 'STIX Two Math', 'XITS Math', 'STIX Math',
+  font-family:
+    'Latin Modern Math', 'STIX Two Math', 'XITS Math', 'STIX Math',
     'Libertinus Math', 'TeX Gyre Termes Math', 'TeX Gyre Bonum Math',
     'TeX Gyre Schola', 'DejaVu Math TeX Gyre', 'TeX Gyre Pagella Math',
     'Asana Math', 'Cambria Math', 'Lucida Bright Math', 'Minion Math',
@@ -135,158 +137,180 @@ math {
 }
 
 :lang(ar) {
-  --RS__baseFontFamily: 'Geeza Pro', 'Arabic Typesetting', Roboto, Noto,
-    'Noto Naskh Arabic', 'Times New Roman', serif;
+  --RS__baseFontFamily:
+    'Geeza Pro', 'Arabic Typesetting', Roboto, Noto, 'Noto Naskh Arabic',
+    'Times New Roman', serif;
 }
 
 :lang(bn) {
-  --RS__baseFontFamily: 'Kohinoor Bangla', 'Bangla Sangam MN', Vrinda, Roboto,
-    Noto, 'Noto Sans Bengali', sans-serif;
+  --RS__baseFontFamily:
+    'Kohinoor Bangla', 'Bangla Sangam MN', Vrinda, Roboto, Noto,
+    'Noto Sans Bengali', sans-serif;
   --RS__lineHeightCompensation: 1.067;
 }
 
 :lang(bo) {
-  --RS__baseFontFamily: Kailasa, 'Microsoft Himalaya', Roboto, Noto,
-    'Noto Sans Tibetan', sans-serif;
+  --RS__baseFontFamily:
+    Kailasa, 'Microsoft Himalaya', Roboto, Noto, 'Noto Sans Tibetan', sans-serif;
 }
 
 :lang(chr) {
-  --RS__baseFontFamily: 'Plantagenet Cherokee', Roboto, Noto,
-    'Noto Sans Cherokee';
+  --RS__baseFontFamily:
+    'Plantagenet Cherokee', Roboto, Noto, 'Noto Sans Cherokee';
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(fa) {
-  --RS__baseFontFamily: 'Geeza Pro', 'Arabic Typesetting', Roboto, Noto,
-    'Noto Naskh Arabic', 'Times New Roman', serif;
+  --RS__baseFontFamily:
+    'Geeza Pro', 'Arabic Typesetting', Roboto, Noto, 'Noto Naskh Arabic',
+    'Times New Roman', serif;
 }
 
 :lang(gu) {
-  --RS__baseFontFamily: 'Gujarati Sangam MN', 'Nirmala UI', Shruti, Roboto, Noto,
+  --RS__baseFontFamily:
+    'Gujarati Sangam MN', 'Nirmala UI', Shruti, Roboto, Noto,
     'Noto Sans Gujarati', sans-serif;
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(he) {
-  --RS__baseFontFamily: 'New Peninim MT', 'Arial Hebrew', Gisha,
-    'Times New Roman', Roboto, Noto, 'Noto Sans Hebrew' sans-serif;
+  --RS__baseFontFamily:
+    'New Peninim MT', 'Arial Hebrew', Gisha, 'Times New Roman', Roboto, Noto,
+    'Noto Sans Hebrew' sans-serif;
   --RS__lineHeightCompensation: 1.1;
 }
 
 :lang(hi) {
-  --RS__baseFontFamily: 'Kohinoor Devanagari', 'Devanagari Sangam MN', Kokila,
-    'Nirmala UI', Roboto, Noto, 'Noto Sans Devanagari', sans-serif;
+  --RS__baseFontFamily:
+    'Kohinoor Devanagari', 'Devanagari Sangam MN', Kokila, 'Nirmala UI', Roboto,
+    Noto, 'Noto Sans Devanagari', sans-serif;
 
   --RS__lineHeightCompensation: 1.1;
 }
 
 :lang(hy) {
-  --RS__baseFontFamily: Mshtakan, Sylfaen, Roboto, Noto, 'Noto Serif Armenian',
-    serif;
+  --RS__baseFontFamily:
+    Mshtakan, Sylfaen, Roboto, Noto, 'Noto Serif Armenian', serif;
 }
 
 :lang(iu) {
-  --RS__baseFontFamily: 'Euphemia UCAS', Euphemia, Roboto, Noto,
-    'Noto Sans Canadian Aboriginal', sans-serif;
+  --RS__baseFontFamily:
+    'Euphemia UCAS', Euphemia, Roboto, Noto, 'Noto Sans Canadian Aboriginal',
+    sans-serif;
 }
 
 :lang(ja) {
-  --RS__baseFontFamily: '游ゴシック体', YuGothic, 'ヒラギノ丸ゴ',
-    'Hiragino Sans', 'Yu Gothic UI', 'Meiryo UI', 'MS Gothic', Roboto, Noto,
-    'Noto Sans CJK JP', sans-serif;
+  --RS__baseFontFamily:
+    '游ゴシック体', YuGothic, 'ヒラギノ丸ゴ', 'Hiragino Sans', 'Yu Gothic UI',
+    'Meiryo UI', 'MS Gothic', Roboto, Noto, 'Noto Sans CJK JP', sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */
   --RS__lineHeightCompensation: 1.167;
 
   /* Extra variables for Japanese font-stacks as we may want to reuse them for user settings + default */
-  --RS__serif-ja: 'ＭＳ Ｐ明朝', 'MS PMincho', 'Hiragino Mincho Pro',
-    'ヒラギノ明朝 Pro W3', '游明朝', 'YuMincho', 'ＭＳ 明朝', 'MS Mincho',
-    'Hiragino Mincho ProN', serif;
-  --RS__sans-serif-ja: 'ＭＳ Ｐゴシック', 'MS PGothic',
-    'Hiragino Kaku Gothic Pro W3', 'ヒラギノ角ゴ Pro W3', 'Hiragino Sans GB',
-    'ヒラギノ角ゴシック W3', '游ゴシック', 'YuGothic', 'ＭＳ ゴシック',
-    'MS Gothic', 'Hiragino Sans', sans-serif;
-  --RS__serif-ja-v: 'ＭＳ 明朝', 'MS Mincho', 'Hiragino Mincho Pro',
-    'ヒラギノ明朝 Pro W3', '游明朝', 'YuMincho', 'ＭＳ Ｐ明朝', 'MS PMincho',
-    'Hiragino Mincho ProN', serif;
-  --RS__sans-serif-ja-v: 'ＭＳ ゴシック', 'MS Gothic',
-    'Hiragino Kaku Gothic Pro W3', 'ヒラギノ角ゴ Pro W3', 'Hiragino Sans GB',
-    'ヒラギノ角ゴシック W3', '游ゴシック', 'YuGothic', 'ＭＳ Ｐゴシック',
-    'MS PGothic', 'Hiragino Sans', sans-serif;
+  --RS__serif-ja:
+    'ＭＳ Ｐ明朝', 'MS PMincho', 'Hiragino Mincho Pro', 'ヒラギノ明朝 Pro W3',
+    '游明朝', 'YuMincho', 'ＭＳ 明朝', 'MS Mincho', 'Hiragino Mincho ProN',
+    serif;
+  --RS__sans-serif-ja:
+    'ＭＳ Ｐゴシック', 'MS PGothic', 'Hiragino Kaku Gothic Pro W3',
+    'ヒラギノ角ゴ Pro W3', 'Hiragino Sans GB', 'ヒラギノ角ゴシック W3',
+    '游ゴシック', 'YuGothic', 'ＭＳ ゴシック', 'MS Gothic', 'Hiragino Sans',
+    sans-serif;
+  --RS__serif-ja-v:
+    'ＭＳ 明朝', 'MS Mincho', 'Hiragino Mincho Pro', 'ヒラギノ明朝 Pro W3',
+    '游明朝', 'YuMincho', 'ＭＳ Ｐ明朝', 'MS PMincho', 'Hiragino Mincho ProN',
+    serif;
+  --RS__sans-serif-ja-v:
+    'ＭＳ ゴシック', 'MS Gothic', 'Hiragino Kaku Gothic Pro W3',
+    'ヒラギノ角ゴ Pro W3', 'Hiragino Sans GB', 'ヒラギノ角ゴシック W3',
+    '游ゴシック', 'YuGothic', 'ＭＳ Ｐゴシック', 'MS PGothic', 'Hiragino Sans',
+    sans-serif;
 }
 
 :lang(km) {
-  --RS__baseFontFamily: 'Khmer Sangam MN', 'Leelawadee UI', 'Khmer UI', Roboto,
-    Noto, 'Noto Sans Khmer', sans-serif;
+  --RS__baseFontFamily:
+    'Khmer Sangam MN', 'Leelawadee UI', 'Khmer UI', Roboto, Noto,
+    'Noto Sans Khmer', sans-serif;
   --RS__lineHeightCompensation: 1.067;
 }
 
 :lang(kn) {
-  --RS__baseFontFamily: 'Kannada Sangam MN', 'Nirmala UI', Tunga, Roboto, Noto,
-    'Noto Sans Kannada', sans-serif;
+  --RS__baseFontFamily:
+    'Kannada Sangam MN', 'Nirmala UI', Tunga, Roboto, Noto, 'Noto Sans Kannada',
+    sans-serif;
   --RS__lineHeightCompensation: 1.1;
 }
 
 :lang(ko) {
-  --RS__baseFontFamily: 'Nanum Gothic', 'Apple SD Gothic Neo', 'Malgun Gothic',
-    Roboto, Noto, 'Noto Sans CJK KR', sans-serif;
+  --RS__baseFontFamily:
+    'Nanum Gothic', 'Apple SD Gothic Neo', 'Malgun Gothic', Roboto, Noto,
+    'Noto Sans CJK KR', sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(lo) {
-  --RS__baseFontFamily: 'Lao Sangam MN', 'Leelawadee UI', 'Lao UI', Roboto, Noto,
-    'Noto Sans Lao', sans-serif;
+  --RS__baseFontFamily:
+    'Lao Sangam MN', 'Leelawadee UI', 'Lao UI', Roboto, Noto, 'Noto Sans Lao',
+    sans-serif;
 }
 
 :lang(ml) {
-  --RS__baseFontFamily: 'Malayalam Sangam MN', 'Nirmala UI', Kartika, Roboto,
-    Noto, 'Noto Sans Malayalam', sans-serif;
+  --RS__baseFontFamily:
+    'Malayalam Sangam MN', 'Nirmala UI', Kartika, Roboto, Noto,
+    'Noto Sans Malayalam', sans-serif;
   --RS__lineHeightCompensation: 1.067;
 }
 
 :lang(or) {
-  --RS__baseFontFamily: 'Oriya Sangam MN', 'Nirmala UI', Kalinga, Roboto, Noto,
-    'Noto Sans Oriya', sans-serif;
+  --RS__baseFontFamily:
+    'Oriya Sangam MN', 'Nirmala UI', Kalinga, Roboto, Noto, 'Noto Sans Oriya',
+    sans-serif;
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(pa) {
-  --RS__baseFontFamily: 'Gurmukhi MN', 'Nirmala UI', Kartika, Roboto, Noto,
-    'Noto Sans Gurmukhi', sans-serif;
+  --RS__baseFontFamily:
+    'Gurmukhi MN', 'Nirmala UI', Kartika, Roboto, Noto, 'Noto Sans Gurmukhi',
+    sans-serif;
   --RS__lineHeightCompensation: 1.1;
 }
 
 :lang(si) {
-  --RS__baseFontFamily: 'Sinhala Sangam MN', 'Nirmala UI', 'Iskoola Pota',
-    Roboto, Noto, 'Noto Sans Sinhala', sans-serif;
+  --RS__baseFontFamily:
+    'Sinhala Sangam MN', 'Nirmala UI', 'Iskoola Pota', Roboto, Noto,
+    'Noto Sans Sinhala', sans-serif;
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(ta) {
-  --RS__baseFontFamily: 'Tamil Sangam MN', 'Nirmala UI', Latha, Roboto, Noto,
-    'Noto Sans Tamil', sans-serif;
+  --RS__baseFontFamily:
+    'Tamil Sangam MN', 'Nirmala UI', Latha, Roboto, Noto, 'Noto Sans Tamil',
+    sans-serif;
   --RS__lineHeightCompensation: 1.067;
 }
 
 :lang(te) {
-  --RS__baseFontFamily: 'Kohinoor Telugu', 'Telugu Sangam MN', 'Nirmala UI',
-    Gautami, Roboto, Noto, 'Noto Sans Telugu', sans-serif;
+  --RS__baseFontFamily:
+    'Kohinoor Telugu', 'Telugu Sangam MN', 'Nirmala UI', Gautami, Roboto, Noto,
+    'Noto Sans Telugu', sans-serif;
 }
 
 :lang(th) {
-  --RS__baseFontFamily: 'Thonburi', 'Leelawadee UI', 'Cordia New', Roboto, Noto,
-    'Noto Sans Thai', sans-serif;
+  --RS__baseFontFamily:
+    'Thonburi', 'Leelawadee UI', 'Cordia New', Roboto, Noto, 'Noto Sans Thai',
+    sans-serif;
   --RS__lineHeightCompensation: 1.067;
 }
 
 /* The following will also work for zh-Hans */
 
 :lang(zh) {
-  --RS__baseFontFamily: '方体', 'PingFang SC', '黑体', 'Heiti SC',
-    'Microsoft JhengHei UI', 'Microsoft JhengHei', Roboto, Noto,
-    'Noto Sans CJK SC', sans-serif;
+  --RS__baseFontFamily:
+    '方体', 'PingFang SC', '黑体', 'Heiti SC', 'Microsoft JhengHei UI',
+    'Microsoft JhengHei', Roboto, Noto, 'Noto Sans CJK SC', sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */
   --RS__lineHeightCompensation: 1.167;
@@ -294,17 +318,18 @@ math {
 
 :lang(zh-Hant),
 :lang(zh-TW) {
-  --RS__baseFontFamily: '方體', 'PingFang TC', '黑體', 'Heiti TC',
-    'Microsoft JhengHei UI', 'Microsoft JhengHei', Roboto, Noto,
-    'Noto Sans CJK TC', sans-serif;
+  --RS__baseFontFamily:
+    '方體', 'PingFang TC', '黑體', 'Heiti TC', 'Microsoft JhengHei UI',
+    'Microsoft JhengHei', Roboto, Noto, 'Noto Sans CJK TC', sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */
   --RS__lineHeightCompensation: 1.167;
 }
 
 :lang(zh-HK) {
-  --RS__baseFontFamily: '方體', 'PingFang HK', '方體', 'PingFang TC', '黑體',
-    'Heiti TC', 'Microsoft JhengHei UI', 'Microsoft JhengHei', Roboto, Noto,
+  --RS__baseFontFamily:
+    '方體', 'PingFang HK', '方體', 'PingFang TC', '黑體', 'Heiti TC',
+    'Microsoft JhengHei UI', 'Microsoft JhengHei', Roboto, Noto,
     'Noto Sans CJK TC', sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */

--- a/src/HtmlReader/effects.ts
+++ b/src/HtmlReader/effects.ts
@@ -134,13 +134,11 @@ export function setFixedCss(
 ): void {
   if (!iframeContainer) return;
 
-  let { contentWidth, contentHeight } = extractContentViewportSize(
-    iframeDocument
-  );
+  let { contentWidth, contentHeight } =
+    extractContentViewportSize(iframeDocument);
 
-  const { containerWidth, containerHeight } = extractContentContainerSize(
-    iframeContainer
-  );
+  const { containerWidth, containerHeight } =
+    extractContentContainerSize(iframeContainer);
 
   // Make it default scale of 1 in case we don't have the content width/height
   contentWidth = contentWidth ?? containerWidth;
@@ -173,9 +171,10 @@ export function setFixedCss(
 /**
  * Extract the publication's width and height from the iframe viewport meta tag.
  */
-function extractContentViewportSize(
-  iframeDocument: Document
-): { contentWidth: number | undefined; contentHeight: number | undefined } {
+function extractContentViewportSize(iframeDocument: Document): {
+  contentWidth: number | undefined;
+  contentHeight: number | undefined;
+} {
   const viewport = iframeDocument?.querySelector('meta[name="viewport"]');
   const content = viewport?.getAttribute('content');
 
@@ -191,9 +190,10 @@ function extractContentViewportSize(
 /**
  * Extract the width and height of the main container where iframe resides.
  */
-function extractContentContainerSize(
-  container: HTMLElement
-): { containerWidth: number; containerHeight: number } {
+function extractContentContainerSize(container: HTMLElement): {
+  containerWidth: number;
+  containerHeight: number;
+} {
   return {
     containerWidth: container.clientWidth,
     containerHeight: container.clientHeight,

--- a/src/HtmlReader/index.tsx
+++ b/src/HtmlReader/index.tsx
@@ -73,7 +73,7 @@ export default function useHtmlReader(args: HtmlReaderArguments): ReaderReturn {
    * the webpubManifestUrl as the key.
    */
   const identifier = manifest
-    ? manifest.metadata.identifier ?? webpubManifestUrl ?? null
+    ? (manifest.metadata.identifier ?? webpubManifestUrl ?? null)
     : null;
   useUpdateLocalStorage(identifier, state, args);
 
@@ -238,7 +238,7 @@ export default function useHtmlReader(args: HtmlReaderArguments): ReaderReturn {
   const englishTitle =
     typeof manifest.metadata.title === 'string'
       ? manifest.metadata.title
-      : manifest.metadata.title.en ?? 'Unknown Title';
+      : (manifest.metadata.title.en ?? 'Unknown Title');
 
   const resourceIndex = manifest.readingOrder.findIndex((link) =>
     isSameResource(link.href, state.location.href, webpubManifestUrl)

--- a/src/HtmlReader/lib.ts
+++ b/src/HtmlReader/lib.ts
@@ -207,9 +207,10 @@ export function calcPosition(
 /**
  * Gets scroll position of an element
  */
-export function getScrollPosition(
-  element: HTMLElement | undefined | null
-): { x: number; y: number } {
+export function getScrollPosition(element: HTMLElement | undefined | null): {
+  x: number;
+  y: number;
+} {
   if (!element) return { x: 0, y: 0 };
   const { scrollTop, scrollLeft } = element;
   return {

--- a/src/HtmlReader/reducer.ts
+++ b/src/HtmlReader/reducer.ts
@@ -134,8 +134,8 @@ export default function makeHtmlReducer(
         const location = isQueryValid
           ? queryLocation
           : isLocalStorageLocationValid
-          ? localStorageRecord.location
-          : defaultStartLocation;
+            ? localStorageRecord.location
+            : defaultStartLocation;
 
         // get initial settings from local storage, if they exist
         const settings =

--- a/src/HtmlReader/useResource.tsx
+++ b/src/HtmlReader/useResource.tsx
@@ -34,7 +34,7 @@ export default function useResource(
       try {
         const content = await getContent(url);
         const mimetype =
-          state.location?.type ?? url.endsWith('.html')
+          (state.location?.type ?? url.endsWith('.html'))
             ? 'text/html'
             : 'application/xhtml+xml';
         const document = new DOMParser().parseFromString(content, mimetype);
@@ -54,9 +54,8 @@ export default function useResource(
         injectJS(document.body);
 
         // While fetching, the page renders a progressbar with skeleton
-        const iframeContainer: HTMLElement | null = window.document.querySelector(
-          'main [role="progressbar"]'
-        );
+        const iframeContainer: HTMLElement | null =
+          window.document.querySelector('main [role="progressbar"]');
 
         const readerSettings = {
           colorMode: state.settings.colorMode,

--- a/src/PdfReader/ScrollPage.tsx
+++ b/src/PdfReader/ScrollPage.tsx
@@ -73,10 +73,10 @@ const ScrollPage: FC<ScrollPageProps> = ({
   );
 
   React.useEffect(() => {
-    if (onInView && entry) {
+    if (allowInView && onInView && entry) {
       onInView(pageNumber, entry.intersectionRatio || 0);
     }
-  }, [entry, onInView, pageNumber]);
+  }, [allowInView, entry, onInView, pageNumber]);
 
   return (
     <div ref={setRefs}>

--- a/src/PdfReader/addTocToManifest.tsx
+++ b/src/PdfReader/addTocToManifest.tsx
@@ -31,7 +31,7 @@ export default async function addTocToManifest(
         // get the page referance
         const ref = dest[0];
         // the return value is improperly typed in the pdfjs library, and so we have to cast it here.
-        const pageIndex = ((await pdf.getPageIndex(ref)) as unknown) as number;
+        const pageIndex = (await pdf.getPageIndex(ref)) as unknown as number;
         // just in case the above cast is incorrect, we will check that pageIndex is a number
         if (typeof pageIndex !== 'number') return undefined;
         if (pageIndex) {

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -1,21 +1,21 @@
 import { Flex } from '@chakra-ui/react';
 import * as React from 'react';
 import { Document, PageProps, pdfjs } from 'react-pdf';
-import { FitMode, ReaderReturn } from '../types';
-import ChakraPage from './ChakraPage';
-import ScrollPage from './ScrollPage';
-import useMeasure from './useMeasure';
 import {
   DEFAULT_HEIGHT,
   DEFAULT_SHOULD_GROW_WHEN_SCROLLING,
   MAIN_CONTENT_ID,
   READER_MARGIN,
 } from '../constants';
+import { FitMode, ReaderReturn } from '../types';
 import LoadingSkeleton from '../ui/LoadingSkeleton';
+import ChakraPage from './ChakraPage';
 import { fetchAsUint8Array, getResourceUrl, SCALE_STEP } from './lib';
 import './pdfReader.css';
 import { makePdfReducer } from './reducer';
+import ScrollPage from './ScrollPage';
 import { PdfReaderArguments } from './types';
+import useMeasure from './useMeasure';
 
 /**
  * The PDF reader
@@ -222,6 +222,10 @@ export default function usePdfReader(args: PdfReaderArguments): ReaderReturn {
     if (!state.settings?.isScrolling) return;
     // if the resource is not yet loaded, don't do anything yet
     if (!state.rendered) return;
+    if (scrollState.current.isInViewUpdate) {
+      scrollState.current.isInViewUpdate = false;
+      return;
+    }
     process.nextTick(() => {
       const page = document.querySelector(
         `[data-page-number="${state.pageNumber}"]`
@@ -280,32 +284,43 @@ export default function usePdfReader(args: PdfReaderArguments): ReaderReturn {
     dispatch({ type: 'SET_FIT_MODE', fitMode: mode });
   }, []);
 
-  const intersectionRatios = React.useRef<{ [page: number]: number }>({});
-  const lastMostVisiblePage = React.useRef<number>(state.pageNumber);
+  const scrollState = React.useRef({
+    ratios: new Map<number, number>(),
+    lastVisiblepage: state.pageNumber,
+    hasScrolled: false,
+    isInViewUpdate: false,
+  });
 
   const onInView = React.useCallback(
     (pageNum: number, ratio: number) => {
+      const currentScrollState = scrollState.current;
       if (!state.settings?.isScrolling) return;
-      intersectionRatios.current[pageNum] = ratio;
 
-      Object.keys(intersectionRatios.current).forEach((key) => {
-        if (intersectionRatios.current[Number(key)] === 0) {
-          delete intersectionRatios.current[Number(key)];
+      currentScrollState.ratios.set(pageNum, ratio);
+
+      if (!currentScrollState.hasScrolled && state.pageNumber === 1) {
+        const container = document.querySelector(
+          `#${MAIN_CONTENT_ID} .react-pdf__Document`
+        );
+        if (container && container.scrollTop > 0)
+          currentScrollState.hasScrolled = true;
+        else return;
+      }
+
+      let mostVisiblePage = currentScrollState.lastVisiblepage;
+      let maxRatio = -1;
+
+      currentScrollState.ratios.forEach((r, p) => {
+        if (r > maxRatio) {
+          maxRatio = r;
+          mostVisiblePage = p;
         }
       });
 
-      let maxRatio = -1;
-      let mostVisiblePage = state.pageNumber;
-      for (const [page, r] of Object.entries(intersectionRatios.current)) {
-        if (r > maxRatio) {
-          maxRatio = r;
-          mostVisiblePage = Number(page);
-        }
-      }
-
-      if (mostVisiblePage !== lastMostVisiblePage.current) {
-        lastMostVisiblePage.current = mostVisiblePage;
+      if (mostVisiblePage !== currentScrollState.lastVisiblepage) {
+        currentScrollState.lastVisiblepage = mostVisiblePage;
         if (state.pageNumber !== mostVisiblePage) {
+          currentScrollState.isInViewUpdate = true;
           dispatch({ type: 'PAGE_IN_VIEW', page: mostVisiblePage });
         }
       }
@@ -447,7 +462,7 @@ export default function usePdfReader(args: PdfReaderArguments): ReaderReturn {
                     scale={state.scale}
                     pageNumber={index + 1}
                     onLoadSuccess={onRenderSuccess}
-                    allowInView={!isFetching}
+                    allowInView={state.rendered}
                     onInView={onInView}
                     fitMode={state.fitMode}
                     rotate={state.rotation ?? 0}

--- a/src/PdfReader/useMeasure.tsx
+++ b/src/PdfReader/useMeasure.tsx
@@ -11,7 +11,7 @@ export type Dimensions = Pick<
 export type UseMeasureRef<E extends Element = Element> = (element: E) => void;
 export type UseMeasureResult<E extends Element = Element> = [
   UseMeasureRef<E> | null,
-  Dimensions
+  Dimensions,
 ];
 
 const DEFAULT_DIMENSION = {
@@ -26,7 +26,7 @@ const DEFAULT_DIMENSION = {
 };
 
 export default function useMeasure<
-  E extends Element = Element
+  E extends Element = Element,
 >(): UseMeasureResult<E> {
   // this is a little trick to get a reference to an HTML element. Using useRef wouldn't
   // work because we actually need rerenders when it changes, to update the useLayoutEffect
@@ -50,16 +50,8 @@ export default function useMeasure<
           }[]
         ) => {
           if (entries[0]) {
-            const {
-              x,
-              y,
-              width,
-              height,
-              top,
-              left,
-              bottom,
-              right,
-            } = entries[0].contentRect;
+            const { x, y, width, height, top, left, bottom, right } =
+              entries[0].contentRect;
             setRect({ x, y, width, height, top, left, bottom, right });
           }
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,8 +28,7 @@ export const DEFAULT_FONT_WIDTH = 250;
 export const FONT_DETAILS = {
   publisher: {
     heading: "Publisher's default font",
-    body:
-      "Show the publisher's-specified fonts and layout choices in this ebook",
+    body: "Show the publisher's-specified fonts and layout choices in this ebook",
     token: 'body',
     fontWeight: 'light',
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,11 +150,10 @@ export type UseWebReaderArguments<T extends string | Uint8Array> = {
   toggleFullScreen?: () => void;
 };
 
-export type ActiveReaderArguments<
-  T extends string | Uint8Array
-> = UseWebReaderArguments<T> & {
-  manifest: WebpubManifest;
-};
+export type ActiveReaderArguments<T extends string | Uint8Array> =
+  UseWebReaderArguments<T> & {
+    manifest: WebpubManifest;
+  };
 
 export type InactiveReaderArguments = undefined;
 

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -29,14 +29,8 @@ export default function Header(
 ): React.ReactElement {
   const [, toggleFullscreenHook] = useFullscreen();
   const [isFullscreen, setIsFullScreen] = useState(false);
-  const {
-    navigator,
-    manifest,
-    type,
-    containerRef,
-    currentPage,
-    totalPages,
-  } = props;
+  const { navigator, manifest, type, containerRef, currentPage, totalPages } =
+    props;
 
   const isAtStart = props.state?.atStart;
   const isAtEnd = props.state?.atEnd;

--- a/src/ui/menu/menu.tsx
+++ b/src/ui/menu/menu.tsx
@@ -206,7 +206,7 @@ const StyledMenuItem = forwardRef<StyledMenuItemProps, 'button'>(
      * Else, use no type to avoid invalid html, e.g. <a type="button" />
      * Else, fall back to "button"
      */
-    const btnType = rest.as ? type ?? undefined : 'button';
+    const btnType = rest.as ? (type ?? undefined) : 'button';
 
     const buttonStyles: SystemStyleObject = {
       textDecoration: 'none',
@@ -227,11 +227,10 @@ const StyledMenuItem = forwardRef<StyledMenuItemProps, 'button'>(
   }
 );
 
-interface MenuItemOptions
-  extends Pick<
-    UseMenuItemProps,
-    'isDisabled' | 'isFocusable' | 'closeOnSelect'
-  > {
+interface MenuItemOptions extends Pick<
+  UseMenuItemProps,
+  'isDisabled' | 'isFocusable' | 'closeOnSelect'
+> {
   /**
    * The icon to render before the menu item's label.
    * @type React.ReactElement
@@ -256,8 +255,7 @@ interface MenuItemOptions
 type HTMLAttributes = React.HTMLAttributes<HTMLElement>;
 
 export interface MenuItemProps
-  extends HTMLChakraProps<'button'>,
-    MenuItemOptions {}
+  extends HTMLChakraProps<'button'>, MenuItemOptions {}
 
 export const MenuItem = forwardRef<MenuItemProps, 'button'>((props, ref) => {
   const {
@@ -311,7 +309,8 @@ const CheckIcon: React.FC<PropsOf<'svg'>> = (props) => (
 );
 
 export interface MenuItemOptionProps
-  extends UseMenuOptionOptions,
+  extends
+    UseMenuOptionOptions,
     Omit<MenuItemProps, keyof UseMenuOptionOptions> {
   /**
    * @type React.ReactElement
@@ -354,7 +353,8 @@ if (__DEV__) {
 }
 
 export interface MenuOptionGroupProps
-  extends UseMenuOptionGroupProps,
+  extends
+    UseMenuOptionGroupProps,
     Omit<MenuGroupProps, 'value' | 'defaultValue' | 'onChange'> {}
 
 export const MenuOptionGroup: React.FC<MenuOptionGroupProps> = (props) => {

--- a/src/ui/menu/use-menu.tsx
+++ b/src/ui/menu/use-menu.tsx
@@ -301,8 +301,10 @@ export interface UseMenuReturn extends ReturnType<typeof useMenu> {}
 /* -------------------------------------------------------------------------------------------------
  * useMenuButton hook
  * -----------------------------------------------------------------------------------------------*/
-export interface UseMenuButtonProps
-  extends Omit<React.HTMLAttributes<Element>, 'color'> {}
+export interface UseMenuButtonProps extends Omit<
+  React.HTMLAttributes<Element>,
+  'color'
+> {}
 
 /**
  * React Hook to manage a menu button.
@@ -373,8 +375,10 @@ function isTargetMenuItem(target: EventTarget | null) {
  * useMenuList
  * -----------------------------------------------------------------------------------------------*/
 
-export interface UseMenuListProps
-  extends Omit<React.HTMLAttributes<Element>, 'color'> {}
+export interface UseMenuListProps extends Omit<
+  React.HTMLAttributes<Element>,
+  'color'
+> {}
 
 /**
  * React Hook to manage a menu list.
@@ -520,8 +524,10 @@ export function useMenuList(
    We also use it in `useMenuItemOption`
  * -----------------------------------------------------------------------------------------------*/
 
-export interface UseMenuItemProps
-  extends Omit<React.HTMLAttributes<Element>, 'color'> {
+export interface UseMenuItemProps extends Omit<
+  React.HTMLAttributes<Element>,
+  'color'
+> {
   /**
    * If `true`, the menuitem will be disabled
    */
@@ -665,8 +671,7 @@ export interface UseMenuOptionOptions {
 }
 
 export interface UseMenuOptionProps
-  extends UseMenuItemProps,
-    UseMenuOptionOptions {}
+  extends UseMenuItemProps, UseMenuOptionOptions {}
 
 export function useMenuOption(
   props: UseMenuOptionProps = {},

--- a/src/ui/theme/components/button.ts
+++ b/src/ui/theme/components/button.ts
@@ -20,7 +20,7 @@ const getButtonStyle = (getColor: GetColor) =>
       size: 'sm',
       variant: 'solid',
     },
-  } as const);
+  }) as const;
 
 /* Color Schemes:
  ** Light, Sepia, Dark
@@ -31,100 +31,98 @@ const getButtonStyle = (getColor: GetColor) =>
  ** Hovered
  */
 
-const variantSolid = (getColor: GetColor) => (
-  props: React.ComponentProps<typeof Button>
-) => {
-  const { 'aria-expanded': expanded } = props;
+const variantSolid =
+  (getColor: GetColor) => (props: React.ComponentProps<typeof Button>) => {
+    const { 'aria-expanded': expanded } = props;
 
-  const bgColor = getColor('ui.gray.light-warm', 'ui.black', 'ui.sepia');
+    const bgColor = getColor('ui.gray.light-warm', 'ui.black', 'ui.sepia');
 
-  const bgColorActive = getColor(
-    'ui.gray.active',
-    'ui.gray.x-dark',
-    'ui.sepiaChecked'
-  );
-  const color = getColor('gray.800', 'ui.white', 'gray.800');
+    const bgColorActive = getColor(
+      'ui.gray.active',
+      'ui.gray.x-dark',
+      'ui.sepiaChecked'
+    );
+    const color = getColor('gray.800', 'ui.white', 'gray.800');
 
-  const _focus = {
-    bgColor: bgColorActive,
-    color,
-    ring: '2px',
-    ringInset: 'inset',
-  };
-  const _hover = {
-    bgColor: bgColorActive,
-    color,
-    _disabled: { bgColor },
-  };
-  const _active = { bgColor: bgColorActive, color };
-  const _checked = { bgColor, color };
-  const _disabled = { bgColor };
-
-  return {
-    border: 'none',
-    borderColor: 'gray.100',
-    height: '45px',
-    transition: 'none',
-    fontSize: 0,
-    letterSpacing: 1,
-    maxWidth: '100%',
-    cursor: 'pointer',
-    bgColor: expanded ? bgColorActive : bgColor,
-    color,
-    _focus,
-    _hover,
-    _active,
-    _checked,
-    _disabled,
-  };
-};
-
-const variantSettings = (getColor: GetColor) => (
-  props: React.ComponentProps<typeof Button>
-) => {
-  const { bgColor } = props;
-
-  const color = getColor('ui.black', 'ui.white', 'ui.black');
-
-  const checkedBgColor = getColor(
-    'ui.gray.light-warm',
-    'ui.gray.x-dark',
-    'ui.sepiaChecked'
-  );
-
-  return {
-    ...variantSolid(getColor)(props),
-    bgColor: getColor('ui.white', 'ui.black', 'ui.sepia'),
-    border: '1px solid',
-    color,
-    py: 8,
-    width: [8, 16, 36],
-    fontSize: [0, 0, 2],
-    whiteSpace: ['normal', 'normal', 'nowrap'],
-    p: {
-      textAlign: 'center',
-    },
-    _active: {
-      bgColor,
-    },
-    _checked: {
+    const _focus = {
+      bgColor: bgColorActive,
       color,
-      bgColor: checkedBgColor,
-      borderBottomColor: checkedBgColor,
-      p: {
-        textDecoration: 'underline',
-        textUnderlinePosition: 'under',
-      },
-    },
-    _hover: {
-      bgColor,
-    },
-    _focus: {
-      bgColor,
       ring: '2px',
       ringInset: 'inset',
-    },
+    };
+    const _hover = {
+      bgColor: bgColorActive,
+      color,
+      _disabled: { bgColor },
+    };
+    const _active = { bgColor: bgColorActive, color };
+    const _checked = { bgColor, color };
+    const _disabled = { bgColor };
+
+    return {
+      border: 'none',
+      borderColor: 'gray.100',
+      height: '45px',
+      transition: 'none',
+      fontSize: 0,
+      letterSpacing: 1,
+      maxWidth: '100%',
+      cursor: 'pointer',
+      bgColor: expanded ? bgColorActive : bgColor,
+      color,
+      _focus,
+      _hover,
+      _active,
+      _checked,
+      _disabled,
+    };
   };
-};
+
+const variantSettings =
+  (getColor: GetColor) => (props: React.ComponentProps<typeof Button>) => {
+    const { bgColor } = props;
+
+    const color = getColor('ui.black', 'ui.white', 'ui.black');
+
+    const checkedBgColor = getColor(
+      'ui.gray.light-warm',
+      'ui.gray.x-dark',
+      'ui.sepiaChecked'
+    );
+
+    return {
+      ...variantSolid(getColor)(props),
+      bgColor: getColor('ui.white', 'ui.black', 'ui.sepia'),
+      border: '1px solid',
+      color,
+      py: 8,
+      width: [8, 16, 36],
+      fontSize: [0, 0, 2],
+      whiteSpace: ['normal', 'normal', 'nowrap'],
+      p: {
+        textAlign: 'center',
+      },
+      _active: {
+        bgColor,
+      },
+      _checked: {
+        color,
+        bgColor: checkedBgColor,
+        borderBottomColor: checkedBgColor,
+        p: {
+          textDecoration: 'underline',
+          textUnderlinePosition: 'under',
+        },
+      },
+      _hover: {
+        bgColor,
+      },
+      _focus: {
+        bgColor,
+        ring: '2px',
+        ringInset: 'inset',
+      },
+    };
+  };
 
 export default getButtonStyle;

--- a/src/ui/theme/components/tabs.ts
+++ b/src/ui/theme/components/tabs.ts
@@ -1,10 +1,8 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/styled-system';
 import { GetColor } from '../../../types';
 
-const {
-  defineMultiStyleConfig,
-  definePartsStyle,
-} = createMultiStyleConfigHelpers(['root', 'tab', 'tablist']);
+const { defineMultiStyleConfig, definePartsStyle } =
+  createMultiStyleConfigHelpers(['root', 'tab', 'tablist']);
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const getTabsStyle = (getColor: GetColor) =>

--- a/tests/utils/MockData.tsx
+++ b/tests/utils/MockData.tsx
@@ -192,26 +192,26 @@ const MockPdfReaderState = {
   atEnd: false,
 };
 
-export const MockHtmlSettingsProps = ({
+export const MockHtmlSettingsProps = {
   navigator: MockHtmlNavigator,
   readerState: MockHtmlReaderState,
   paginationValue: 'scrolling',
-} as unknown) as HtmlSettingsProps;
+} as unknown as HtmlSettingsProps;
 
-export const MockHtmlReaderProps = ({
+export const MockHtmlReaderProps = {
   type: 'HTML',
   isLoading: false,
   content: <MockComponent />,
   state: MockHtmlReaderState,
   manifest: MockWebpubManifest,
   navigator: MockHtmlNavigator,
-} as unknown) as ActiveReader;
+} as unknown as ActiveReader;
 
-export const MockPdfReaderProps = ({
+export const MockPdfReaderProps = {
   type: 'PDF',
   isLoading: false,
   content: <MockComponent />,
   state: MockPdfReaderState,
   manifest: MockWebpubManifest,
   navigator: MockPdfNavigator,
-} as unknown) as ActiveReader;
+} as unknown as ActiveReader;


### PR DESCRIPTION
- Adds Playwright folders to .eslintignore
- Runs "prettier" command to format files (required for release)
- Adds settings.json for vscode auto formatting and linter warnings. 
- Fixes an issue where the PDF reader sometimes started at page 2 due to the interaction ratio ref being triggered on page load if the height of the PDF reader is greater than the height of a page.
- Fixes an issue where scrolling upward would jump to the start of the page due to the PAGE_IN_VIEW action being triggered by adding a scroll listener. 