### PR TITLE
Fix initial page drift in PDF scroll mode

### DIFF
--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -2,6 +2,7 @@ import { Flex } from '@chakra-ui/react';
 import * as React from 'react';
 import { Document, PageProps, pdfjs } from 'react-pdf';
 import {
+  ANCHOR_SETTLE_MS,
   DEFAULT_HEIGHT,
   DEFAULT_SHOULD_GROW_WHEN_SCROLLING,
   IN_VIEW_DELAY_MS,
@@ -222,7 +223,13 @@ export default function usePdfReader(args: PdfReaderArguments): ReaderReturn {
   ]);
 
   /**
-   * In scrolling mode, manually scroll the user when the page changes
+   * In scrolling mode, manually scroll the user when the page changes.
+   *
+   * A single scrollTo is not enough: while the PDF streams in, placeholders
+   * are swapped for rendered pages and the fit-mode resize changes every
+   * page's height, both of which shift the target page after we have already
+   * scrolled to it. We keep the target anchored until its position has been
+   * stable for ANCHOR_SETTLE_MS, or until the user interacts with the reader.
    */
   React.useEffect(() => {
     // if the resource is not yet loaded, don't do anything yet
@@ -235,16 +242,59 @@ export default function usePdfReader(args: PdfReaderArguments): ReaderReturn {
     }
 
     const documentContainer = documentContainerRef.current;
-    const pageRef = pageRefs.current.get(state.pageNumber);
+    if (!documentContainer) return;
 
-    if (documentContainer && pageRef) {
-      const containerRect = documentContainer.getBoundingClientRect();
-      const pageRect = pageRef.getBoundingClientRect();
+    const userInteractionEvents = [
+      'wheel',
+      'touchstart',
+      'mousedown',
+      'keydown',
+    ] as const;
+    const targetPage = state.pageNumber;
+    let rafId = 0;
+    let stableSince: number | null = null;
 
-      documentContainer.scrollTo({
-        top: documentContainer.scrollTop + (pageRect.top - containerRect.top),
-      });
-    }
+    const stop = () => {
+      cancelAnimationFrame(rafId);
+      userInteractionEvents.forEach((event) =>
+        documentContainer.removeEventListener(event, stop)
+      );
+    };
+
+    userInteractionEvents.forEach((event) =>
+      documentContainer.addEventListener(event, stop, { passive: true })
+    );
+
+    const anchor = () => {
+      const pageRef = pageRefs.current.get(targetPage);
+      if (pageRef) {
+        const containerRect = documentContainer.getBoundingClientRect();
+        const pageRect = pageRef.getBoundingClientRect();
+        const delta = pageRect.top - containerRect.top;
+
+        if (Math.abs(delta) > 1) {
+          // suppress PAGE_IN_VIEW while we correct, the same way
+          // beginProgrammaticNavigation does for explicit navigation
+          scrollState.current.lastVisiblePage = targetPage;
+          scrollState.current.lastProgrammaticNavAt = Date.now();
+          scrollState.current.ratios.clear();
+
+          documentContainer.scrollTo({
+            top: documentContainer.scrollTop + delta,
+          });
+          stableSince = null;
+        } else if (stableSince === null) {
+          stableSince = Date.now();
+        } else if (Date.now() - stableSince >= ANCHOR_SETTLE_MS) {
+          stop();
+          return;
+        }
+      }
+      rafId = requestAnimationFrame(anchor);
+    };
+
+    anchor();
+    return stop;
   }, [state.pageNumber, state.settings?.isScrolling, state.rendered]);
 
   const beginProgrammaticNavigation = React.useCallback(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,8 @@ export const DEFAULT_FONT_WIDTH = 250;
 export const FONT_DETAILS = {
   publisher: {
     heading: "Publisher's default font",
-    body: "Show the publisher's-specified fonts and layout choices in this ebook",
+    body:
+      "Show the publisher's-specified fonts and layout choices in this ebook",
     token: 'body',
     fontWeight: 'light',
   },
@@ -53,6 +54,9 @@ export const FONT_DETAILS = {
 };
 
 export const IN_VIEW_DELAY_MS = 150;
+// how long the scroll target's position must be stable before we stop
+// re-anchoring it (see the scroll effect in PdfReader)
+export const ANCHOR_SETTLE_MS = 1000;
 
 // local storage keys
 export const LOCAL_STORAGE_SETTINGS_KEY = 'web-reader-settings';


### PR DESCRIPTION
## Problem

When the reader opens with a `start` page in scroll mode (e.g. a manifest `readingOrder` href with `?start=00000262`), the viewer initially shows the requested page number but then drifts to a later page (262 → 274/345 depending on viewport) once the PDF finishes loading.

## Cause

The scroll effect performed a **single** `scrollTo` to the target page as soon as the first page rendered (`state.rendered`). At that moment page slot heights are still provisional: placeholders are later swapped for rendered pages, and the fit-mode resize (`RESIZE_PAGE`) changes every page's height. The layout shift after the one-shot scroll leaves the viewport several pages past the target (measured ~5,900px = 12.4 pages past page 262 with a 480px slot pitch). `PAGE_IN_VIEW` then reports the wrong visible page and, because it sets `isInViewUpdate`, the corrective re-scroll is skipped.

The drift amount depends on the ratio between provisional and final slot heights, which is why different viewports land on different pages.

## Fix

Keep the target page anchored instead of scrolling once:

- Re-check the target page's position every animation frame and correct the scroll offset whenever it moves (layout shifts from page loads / resizes).
- Stop when the position has been stable for `ANCHOR_SETTLE_MS` (1s), or immediately when the user interacts with the reader (`wheel` / `touchstart` / `mousedown` / `keydown`), so user scrolling is never hijacked.
- Each correction refreshes `lastProgrammaticNavAt` / `lastVisiblePage` / `ratios` (same as `beginProgrammaticNavigation`), so `PAGE_IN_VIEW` cannot override the target mid-anchoring.

## Verification

Tested against DRB enhanced-search locally with `/item/...?previewItemId=25443668&previewPage=00000262` (516-page PDF):

- Before: toolbar showed 262, then jumped to 274 after load; `scrollTop` overshot page 262's offset by 12.4 pages.
- After: viewer settles exactly on page 262 (`scrollTop` == page 262 offset, delta 0px) and stays there; manual scrolling afterwards is not pulled back.
- `jest --ci`: 9 suites / 27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)