### PR TITLE
SCHOL-853: Enable range requests for linearized pdfs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5274,9 +5274,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5298,9 +5295,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5322,9 +5316,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5346,9 +5337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5871,9 +5859,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5895,9 +5880,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5919,9 +5901,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5943,9 +5922,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5965,9 +5941,6 @@
       "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5990,9 +5963,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6077,9 +6047,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6273,9 +6240,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6290,9 +6254,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6307,9 +6268,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6324,9 +6282,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6341,9 +6296,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6358,9 +6310,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6375,9 +6324,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6392,9 +6338,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6409,9 +6352,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6426,9 +6366,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6443,9 +6380,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6460,9 +6394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6477,9 +6408,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6719,9 +6647,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6739,9 +6664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6759,9 +6681,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6779,9 +6698,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8305,13 +8221,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.16.tgz",
-      "integrity": "sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -8689,9 +8607,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001765",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
-      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -8706,8 +8624,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/canvas": {
       "version": "3.2.1",
@@ -14638,9 +14555,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14662,9 +14576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14686,9 +14597,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14710,9 +14618,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -19649,6 +19554,23 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/playwright/pageobjects/web-reader.page.ts
+++ b/playwright/pageobjects/web-reader.page.ts
@@ -193,6 +193,7 @@ class PdfReaderPage extends WebReaderPage {
     await this.page.goto(gotoPage, { waitUntil: 'domcontentloaded' });
     await this.loadPage();
     await expect(this.pageOne).toBeVisible();
+    await expect(this.pageOne.locator('.pdf-page-loading')).not.toBeVisible();
     return new WebReaderPage(this.page);
   }
 

--- a/src/PdfReader/PdfPage.tsx
+++ b/src/PdfReader/PdfPage.tsx
@@ -1,6 +1,12 @@
 import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
 import { AnnotationLayer, TextLayer } from 'pdfjs-dist';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { PageSize, RefProxy } from './types';
 import { getRotatedSize, toError } from './utils';
 
@@ -39,6 +45,7 @@ const PdfPage = React.memo(function PdfPage({
   const renderTaskRef = useRef<RenderTask | null>(null);
   const textLayerTaskRef = useRef<{ cancel: () => void } | null>(null);
   const renderedKeyRef = useRef<string | null>(null);
+  const [isContentReady, setIsContentReady] = useState(false);
 
   const releaseRenderedContent = useCallback(() => {
     const canvas = canvasRef.current;
@@ -71,6 +78,7 @@ const PdfPage = React.memo(function PdfPage({
       textLayerTaskRef.current?.cancel();
       textLayerTaskRef.current = null;
       releaseRenderedContent();
+      setIsContentReady(false);
       return undefined;
     }
 
@@ -221,7 +229,10 @@ const PdfPage = React.memo(function PdfPage({
           // Non-fatal: annotation rendering support varies by pdf.js version.
         }
 
-        if (!cancelled) renderedKeyRef.current = key;
+        if (!cancelled) {
+          renderedKeyRef.current = key;
+          setIsContentReady(true);
+        }
       } catch (err: unknown) {
         if (cancelled) return;
         if (
@@ -285,6 +296,11 @@ const PdfPage = React.memo(function PdfPage({
         className="pdf-annotation-layer annotationLayer"
         style={{ width: displayWidth, height: displayHeight }}
       />
+      {!isContentReady && (
+        <div className="pdf-page-loading" aria-hidden="true">
+          <div className="pdf-page-spinner" />
+        </div>
+      )}
     </div>
   );
 });

--- a/src/PdfReader/PdfReaderContent.tsx
+++ b/src/PdfReader/PdfReaderContent.tsx
@@ -562,7 +562,10 @@ const PdfReaderContent = ({
   );
 
   useEffect(() => {
-    if (fitMode) applyFitScale(fitMode);
+    if (fitMode) {
+      userZoomedRef.current = false;
+      applyFitScale(fitMode);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fitMode, pageBaseSizes.length]);
 
@@ -635,7 +638,9 @@ const PdfReaderContent = ({
         suppressNextResizeFitRef.current = false;
         return;
       }
-      if (fitModeRef.current) applyFitScaleRef.current(fitModeRef.current);
+      if (fitModeRef.current && !userZoomedRef.current) {
+        applyFitScaleRef.current(fitModeRef.current);
+      }
     });
     ro.observe(wrap);
     return () => ro.disconnect();

--- a/src/PdfReader/PdfReaderContent.tsx
+++ b/src/PdfReader/PdfReaderContent.tsx
@@ -12,7 +12,9 @@ import { MAIN_CONTENT_ID } from '../constants';
 import ReaderErrorAlert from '../ui/ReaderErrorAlert';
 import PdfPage from './PdfPage';
 import {
+  DEFAULT_PAGE_SIZE,
   PAGE_GAP,
+  PAGE_MEASURE_BUFFER,
   PAGE_PADDING,
   RENDER_ROOT_MARGIN,
   SCROLLSPY_ANCHOR_RATIO,
@@ -45,6 +47,7 @@ const PdfReaderContent = ({
   clearPendingAction,
   onOutlineLoad,
   onPageSizesReady,
+  loadOutline,
   onError,
 }: PdfReaderContentProps): React.ReactElement => {
   const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
@@ -60,6 +63,7 @@ const PdfReaderContent = ({
   const [pageRenderErrors, setPageRenderErrors] = useState<Map<number, Error>>(
     new Map()
   );
+  const [rangeCapable, setRangeCapable] = useState<boolean>(false);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const viewportWrapRef = useRef<HTMLDivElement | null>(null);
@@ -71,6 +75,13 @@ const PdfReaderContent = ({
   const pendingViewportAnchorRef = useRef<ViewportAnchor | null>(null);
   const suppressNextResizeFitRef = useRef(false);
   const onPageSizesReadyRef = useRef(onPageSizesReady);
+  const measuredPagesRef = useRef<Set<number>>(new Set());
+  const initialBatchAppliedRef = useRef(false);
+  const pageBaseSizesRef = useRef<PageSize[]>([]);
+
+  useEffect(() => {
+    pageBaseSizesRef.current = pageBaseSizes;
+  }, [pageBaseSizes]);
 
   useEffect(() => {
     onPageSizesReadyRef.current = onPageSizesReady;
@@ -115,26 +126,39 @@ const PdfReaderContent = ({
     setVisiblePages(new Set());
     setPageRenderErrors(new Map());
     containerRefs.current.clear();
+    setRangeCapable(false);
+
+    fetch(fileUrl, { headers: { Range: 'bytes=0-1' } })
+      .then((res) => {
+        if (cancelled) return;
+        setRangeCapable(
+          res.status === 206 && res.headers.get('Accept-Ranges') === 'bytes'
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setRangeCapable(false);
+      });
 
     const loadDocument = async () => {
       try {
-        loadingTask = getDocument({ url: fileUrl, withCredentials: false });
+        loadingTask = getDocument({
+          url: fileUrl,
+          withCredentials: false,
+          disableStream: true, // Disable streaming to reduce memory pressure
+          disableAutoFetch: true, // Disable background prefetch of non-visible pages
+          rangeChunkSize: 1024 * 1024, // 1MB
+        });
         const doc = await loadingTask.promise;
         if (cancelled) return;
 
         setPdfDoc(doc);
         dispatch({ type: 'PAGES_LOADED', numPages: doc.numPages });
-
-        try {
-          const rawOutline = (await doc.getOutline()) as
-            | PdfOutlineEntry[]
-            | null;
-          if (rawOutline && !cancelled) {
-            onOutlineLoad(await resolveOutline(doc, rawOutline));
-          }
-        } catch {
-          // Outline is optional, ignore failures.
-        }
+        measuredPagesRef.current = new Set();
+        initialBatchAppliedRef.current = false;
+        setPageBaseSizes(
+          Array.from({ length: doc.numPages }, () => DEFAULT_PAGE_SIZE)
+        );
+        onPageSizesReadyRef.current?.();
       } catch (err: unknown) {
         if (cancelled) return;
         const nextError = toError(err, 'Failed to load PDF document');
@@ -152,38 +176,27 @@ const PdfReaderContent = ({
     };
   }, [fileUrl, dispatch, onOutlineLoad]);
 
-  // Read every page's intrinsic size to determine scroll container's height
-  // before any page has actually been painted.
-  // TODO: for very large documents consider windowing this fetch
   useEffect(() => {
-    if (!pdfDoc) return undefined;
+    if (!pdfDoc || !loadOutline) return undefined;
     let cancelled = false;
 
     (async () => {
       try {
-        const sizes: PageSize[] = [];
-        for (let i = 1; i <= pdfDoc.numPages; i += 1) {
-          if (cancelled) return;
-          const page = await pdfDoc.getPage(i);
-          const vp = page.getViewport({ scale: 1, rotation: 0 });
-          sizes.push({ width: vp.width, height: vp.height });
-          // Hint to pdf.js to release temporary resources for this page.
-          page.cleanup();
+        const rawOutline = (await pdfDoc.getOutline()) as
+          | PdfOutlineEntry[]
+          | null;
+        if (rawOutline && !cancelled) {
+          onOutlineLoad(await resolveOutline(pdfDoc, rawOutline));
         }
-        if (cancelled) return;
-        setPageBaseSizes(sizes);
-        onPageSizesReadyRef.current?.();
-      } catch (err: unknown) {
-        if (cancelled) return;
-        const nextError = toError(err, 'Failed to read page dimensions');
-        setError(nextError);
+      } catch {
+        // Outline is optional, ignore failures.
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [pdfDoc]);
+  }, [pdfDoc, onOutlineLoad, loadOutline]);
 
   // Lazy render: observe which pages are near the viewport
   useEffect(() => {
@@ -338,6 +351,159 @@ const PdfReaderContent = ({
     };
   }, [pageBaseSizes, scale, rotation]);
 
+  // Measure the size of the current/visible pages with a buffer, lazily
+  // fetching new pages in view. Only used for linearized PDFs.
+  useEffect(() => {
+    if (!pdfDoc || !pageBaseSizes.length || !rangeCapable) {
+      return undefined;
+    }
+    let cancelled = false;
+
+    const wanted = new Set<number>();
+    const addRange = (center: number) => {
+      const start = Math.max(1, center - PAGE_MEASURE_BUFFER);
+      const end = Math.min(pdfDoc.numPages, center + PAGE_MEASURE_BUFFER);
+      for (let p = start; p <= end; p += 1) wanted.add(p);
+    };
+    addRange(pageNumber);
+    visiblePages.forEach(addRange);
+
+    const toMeasure = Array.from(wanted).filter(
+      (p) => !measuredPagesRef.current.has(p)
+    );
+    if (!toMeasure.length) return undefined;
+
+    (async () => {
+      const updates: { index: number; size: PageSize }[] = [];
+      for (const p of toMeasure) {
+        if (cancelled) return;
+        try {
+          const page = await pdfDoc.getPage(p);
+          if (cancelled) return;
+          const vp = page.getViewport({ scale: 1, rotation: 0 });
+          updates.push({
+            index: p - 1,
+            size: { width: vp.width, height: vp.height },
+          });
+          page.cleanup();
+          measuredPagesRef.current.add(p);
+        } catch (err: unknown) {
+          if (cancelled) return;
+          setError(toError(err, 'Failed to read page dimensions'));
+          return;
+        }
+      }
+      if (cancelled || !updates.length) return;
+      captureViewportAnchor();
+
+      const next = pageBaseSizesRef.current.slice();
+      updates.forEach(({ index, size }) => {
+        next[index] = size;
+      });
+
+      let correctedScale: number | null = null;
+      if (!initialBatchAppliedRef.current) {
+        initialBatchAppliedRef.current = true;
+        const sample = updates[0].size;
+        for (let i = 0; i < next.length; i += 1) {
+          if (!measuredPagesRef.current.has(i + 1)) next[i] = sample;
+        }
+
+        if (fitMode) {
+          const wrap = viewportWrapRef.current;
+          if (wrap) {
+            const refIndex =
+              Math.min(Math.max(currentPageRef.current, 1), next.length) - 1;
+            const rotated = getRotatedSize(next[refIndex], rotation);
+            const widestRotatedPageWidth = next.reduce((maxWidth, page) => {
+              return Math.max(maxWidth, getRotatedSize(page, rotation).width);
+            }, 0);
+            const availWidth = wrap.clientWidth - PAGE_PADDING;
+            const availHeight = wrap.clientHeight - PAGE_PADDING;
+            const newScale =
+              fitMode === 'width'
+                ? availWidth / widestRotatedPageWidth
+                : availHeight / rotated.height;
+            if (newScale > 0) correctedScale = newScale;
+          }
+        }
+      }
+
+      setPageBaseSizes(next);
+      if (correctedScale != null) {
+        suppressNextResizeFitRef.current = true;
+        dispatch({ type: 'SET_SCALE', scale: correctedScale });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    pdfDoc,
+    pageNumber,
+    visiblePages,
+    pageBaseSizes.length,
+    captureViewportAnchor,
+    rangeCapable,
+  ]);
+
+  // Measure every page's size up front. Only used for non-linearized PDFs.
+  useEffect(() => {
+    if (!pdfDoc || rangeCapable) return undefined;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const sizes: PageSize[] = [];
+        for (let i = 1; i <= pdfDoc.numPages; i += 1) {
+          if (cancelled) return;
+          const page = await pdfDoc.getPage(i);
+          const vp = page.getViewport({ scale: 1, rotation: 0 });
+          sizes.push({ width: vp.width, height: vp.height });
+          page.cleanup();
+          measuredPagesRef.current.add(i);
+        }
+        if (cancelled) return;
+
+        let correctedScale: number | null = null;
+        if (fitMode) {
+          const wrap = viewportWrapRef.current;
+          if (wrap) {
+            const refIndex =
+              Math.min(Math.max(currentPageRef.current, 1), sizes.length) - 1;
+            const rotated = getRotatedSize(sizes[refIndex], rotation);
+            const widestRotatedPageWidth = sizes.reduce((maxWidth, page) => {
+              return Math.max(maxWidth, getRotatedSize(page, rotation).width);
+            }, 0);
+            const availWidth = wrap.clientWidth - PAGE_PADDING;
+            const availHeight = wrap.clientHeight - PAGE_PADDING;
+            const newScale =
+              fitMode === 'width'
+                ? availWidth / widestRotatedPageWidth
+                : availHeight / rotated.height;
+            if (newScale > 0) correctedScale = newScale;
+          }
+        }
+
+        setPageBaseSizes(sizes);
+        if (correctedScale != null) {
+          suppressNextResizeFitRef.current = true;
+          dispatch({ type: 'SET_SCALE', scale: correctedScale });
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setError(toError(err, 'Failed to read page dimensions'));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pdfDoc, rangeCapable]);
+
   // Fit-to-width/height
   const computeFitScaleValue = useCallback(
     (mode: FitMode, rotationForCalc: number): number | null => {
@@ -393,6 +559,11 @@ const PdfReaderContent = ({
     [computeFitScaleValue, rotation, captureViewportAnchor, dispatch]
   );
 
+  useEffect(() => {
+    if (fitMode) applyFitScale(fitMode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitMode, pageBaseSizes.length]);
+
   useLayoutEffect(() => {
     const anchor = pendingViewportAnchorRef.current;
     const wrap = viewportWrapRef.current;
@@ -441,11 +612,6 @@ const PdfReaderContent = ({
     rotation,
     dispatch,
   ]);
-
-  useEffect(() => {
-    if (fitMode) applyFitScale(fitMode);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fitMode, pageBaseSizes]);
 
   // Re-apply fit scale on container resize.
   const fitModeRef = useRef(fitMode);

--- a/src/PdfReader/PdfReaderContent.tsx
+++ b/src/PdfReader/PdfReaderContent.tsx
@@ -77,7 +77,6 @@ const PdfReaderContent = ({
   const onPageSizesReadyRef = useRef(onPageSizesReady);
   const measuredPagesRef = useRef<Set<number>>(new Set());
   const initialBatchAppliedRef = useRef(false);
-  const userZoomedRef = useRef(false);
   const pageBaseSizesRef = useRef<PageSize[]>([]);
 
   useEffect(() => {
@@ -156,7 +155,6 @@ const PdfReaderContent = ({
         dispatch({ type: 'PAGES_LOADED', numPages: doc.numPages });
         measuredPagesRef.current = new Set();
         initialBatchAppliedRef.current = false;
-        userZoomedRef.current = false;
         setPageBaseSizes(
           Array.from({ length: doc.numPages }, () => DEFAULT_PAGE_SIZE)
         );
@@ -432,7 +430,7 @@ const PdfReaderContent = ({
       }
 
       setPageBaseSizes(next);
-      if (correctedScale != null && !userZoomedRef.current) {
+      if (correctedScale != null) {
         suppressNextResizeFitRef.current = true;
         dispatch({ type: 'SET_SCALE', scale: correctedScale });
       }
@@ -490,7 +488,7 @@ const PdfReaderContent = ({
         }
 
         setPageBaseSizes(sizes);
-        if (correctedScale != null && !userZoomedRef.current) {
+        if (correctedScale != null) {
           suppressNextResizeFitRef.current = true;
           dispatch({ type: 'SET_SCALE', scale: correctedScale });
         }
@@ -562,10 +560,7 @@ const PdfReaderContent = ({
   );
 
   useEffect(() => {
-    if (fitMode) {
-      userZoomedRef.current = false;
-      applyFitScale(fitMode);
-    }
+    if (fitMode) applyFitScale(fitMode);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fitMode, pageBaseSizes.length]);
 
@@ -592,7 +587,6 @@ const PdfReaderContent = ({
     if (!pendingAction) return;
 
     if (pendingAction.type === 'ZOOM_IN' || pendingAction.type === 'ZOOM_OUT') {
-      userZoomedRef.current = true;
       captureViewportAnchor();
       dispatch({ type: pendingAction.type });
     }
@@ -638,9 +632,7 @@ const PdfReaderContent = ({
         suppressNextResizeFitRef.current = false;
         return;
       }
-      if (fitModeRef.current && !userZoomedRef.current) {
-        applyFitScaleRef.current(fitModeRef.current);
-      }
+      if (fitModeRef.current) applyFitScaleRef.current(fitModeRef.current);
     });
     ro.observe(wrap);
     return () => ro.disconnect();

--- a/src/PdfReader/PdfReaderContent.tsx
+++ b/src/PdfReader/PdfReaderContent.tsx
@@ -77,6 +77,7 @@ const PdfReaderContent = ({
   const onPageSizesReadyRef = useRef(onPageSizesReady);
   const measuredPagesRef = useRef<Set<number>>(new Set());
   const initialBatchAppliedRef = useRef(false);
+  const userZoomedRef = useRef(false);
   const pageBaseSizesRef = useRef<PageSize[]>([]);
 
   useEffect(() => {
@@ -155,6 +156,7 @@ const PdfReaderContent = ({
         dispatch({ type: 'PAGES_LOADED', numPages: doc.numPages });
         measuredPagesRef.current = new Set();
         initialBatchAppliedRef.current = false;
+        userZoomedRef.current = false;
         setPageBaseSizes(
           Array.from({ length: doc.numPages }, () => DEFAULT_PAGE_SIZE)
         );
@@ -430,7 +432,7 @@ const PdfReaderContent = ({
       }
 
       setPageBaseSizes(next);
-      if (correctedScale != null) {
+      if (correctedScale != null && !userZoomedRef.current) {
         suppressNextResizeFitRef.current = true;
         dispatch({ type: 'SET_SCALE', scale: correctedScale });
       }
@@ -488,7 +490,7 @@ const PdfReaderContent = ({
         }
 
         setPageBaseSizes(sizes);
-        if (correctedScale != null) {
+        if (correctedScale != null && !userZoomedRef.current) {
           suppressNextResizeFitRef.current = true;
           dispatch({ type: 'SET_SCALE', scale: correctedScale });
         }
@@ -587,6 +589,7 @@ const PdfReaderContent = ({
     if (!pendingAction) return;
 
     if (pendingAction.type === 'ZOOM_IN' || pendingAction.type === 'ZOOM_OUT') {
+      userZoomedRef.current = true;
       captureViewportAnchor();
       dispatch({ type: pendingAction.type });
     }

--- a/src/PdfReader/constants.ts
+++ b/src/PdfReader/constants.ts
@@ -1,4 +1,5 @@
 // Constants specific to PdfReader (zoom limits, layout spacing, scroll behavior).
+import { PageSize } from './types';
 
 export const MIN_SCALE = 0.25;
 export const MAX_SCALE = 5;
@@ -6,4 +7,6 @@ export const SCALE_STEP = 0.1;
 export const PAGE_GAP = 16;
 export const PAGE_PADDING = 32;
 export const RENDER_ROOT_MARGIN = '300px 0px 300px 0px';
+export const PAGE_MEASURE_BUFFER = 2;
+export const DEFAULT_PAGE_SIZE: PageSize = { width: 612, height: 792 };
 export const SCROLLSPY_ANCHOR_RATIO = 0.3;

--- a/src/PdfReader/index.tsx
+++ b/src/PdfReader/index.tsx
@@ -99,11 +99,13 @@ const usePdfReader = ({
   );
   const [pdfLoadError, setPdfLoadError] = useState<Error | null>(null);
   const [pageSizesReady, setPageSizesReady] = useState(false);
+  const [loadOutline, setLoadOutline] = useState(false);
   const hasNavigatedToInitialPageRef = useRef(false);
 
   useEffect(() => {
     setPdfLoadError(null);
     setPageSizesReady(false);
+    setLoadOutline(false);
     hasNavigatedToInitialPageRef.current = false;
   }, [fileUrl]);
 
@@ -151,6 +153,7 @@ const usePdfReader = ({
       zoomIn: async () => setPendingAction({ type: 'ZOOM_IN' }),
       zoomOut: async () => setPendingAction({ type: 'ZOOM_OUT' }),
       rotateCounterClockwise: () => setPendingAction({ type: 'ROTATE_CCW' }),
+      loadToc: () => setLoadOutline(true),
     }),
     []
   );
@@ -211,6 +214,7 @@ const usePdfReader = ({
           clearPendingAction={clearPendingAction}
           onOutlineLoad={setOutline}
           onPageSizesReady={wrappedOnPageSizesReady}
+          loadOutline={loadOutline}
           onError={handlePdfLoadError}
         />
       )}

--- a/src/PdfReader/pdfReader.css
+++ b/src/PdfReader/pdfReader.css
@@ -81,6 +81,30 @@
   display: block;
 }
 
+.pdf-page-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #252525;
+}
+
+.pdf-page-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  animation: pdf-page-spin 0.8s linear infinite;
+}
+
+@keyframes pdf-page-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Text and annotation layer styles adapted from react-pdf/pdf.js */
 .pdf-root {
   --react-pdf-text-layer: 1;

--- a/src/PdfReader/types.ts
+++ b/src/PdfReader/types.ts
@@ -43,6 +43,7 @@ export interface PdfReaderContentProps {
   clearPendingAction: () => void;
   onOutlineLoad: (outlineItems: OutlineItem[]) => void;
   onPageSizesReady: () => void;
+  loadOutline: boolean;
   onError: (error: Error) => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type Navigator = {
   goToPage: (href: string) => void;
   goToPageNumber: (pageNumber: number) => void;
   setFitMode: (mode: FitMode) => void;
+  loadToc?: () => void;
 };
 
 export type PdfNavigator = Navigator & {

--- a/src/ui/TableOfContent.tsx
+++ b/src/ui/TableOfContent.tsx
@@ -34,7 +34,7 @@ export default function TableOfContent({
     'ui.sepia'
   );
   return (
-    <Menu>
+    <Menu onOpen={() => navigator.loadToc?.()}>
       {({ isOpen }) => (
         <>
           <Tooltip content="Table of contents">


### PR DESCRIPTION
[SCHOL-853](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-853)

## Description

Enables range requests for linearized pdfs to better view large documents.

- `getDocument()` now passes `disableStream: true`, `disableAutoFetch: true`, and `rangeChunkSize` to 1MB (from pdf.js's 64KB default). 

### Windowed page size measurement
- For non-linearized PDFs `PdfReaderContent` calls `pdfDoc.getPage(i)` for every page up front to measure layout height/width.
- For linearized PDFs, it seeds every page with a placeholder size (`DEFAULT_PAGE_SIZE`) so the scroll container exists right away, then only measures the real size of the current page and currently-visible pages (± `PAGE_MEASURE_BUFFER`) as the user scrolls or navigates.
- The placeholder for not-yet-measured pages is updated once the first batch is measured, using the *largest* width/height seen in that batch.
- Scroll position is preserved across placeholder to actual size swaps using the existing `captureViewportAnchor`.

### Lazy Table of Contents
- `resolveOutline()` calls `pdfDoc.getPageIndex()` once per outline entry, which can require a separate range request per entry for documents whose outline touches most of the file.
- Outline resolution is now deferred until the user requests it (opens the TOC panel).

### Loading UX (`PdfPage.tsx`)
- Added a loading indicator shown while a page's canvas/text/annotation layers are still rendering.

## Testing
- Manually verified against local 1230 page PDF initial loads:
    - Normal network (240 Mbps)
        - Before linearization: 834,226 KB (834.22 MB) transferred, 3.8 s
        - After linearization: 6,897 KB (6.897 MB) transferred, 813 ms
    - "Fast 4G" throttling
        - Before linearization: 834,226 KB transferred, 13.8 min
        - After linearization: 6,905 KB (6.905 MB) transferred, 13.39 s

## Future work
- Page size placeholders are not the best for Enhanced Search since the documents do not have uniform page dimensions. If largest page dimensions become available from the manifest then the logic around page measurement can be simplified.

[SCHOL-853]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ